### PR TITLE
Add hybrid search provider option

### DIFF
--- a/app/pages/settings.py
+++ b/app/pages/settings.py
@@ -124,6 +124,7 @@ def show_search_settings(settings_manager: SettingsManager):
         - **Stub**: テスト用のダミーデータ
         - **CSE**: Google Custom Search Engine
         - **NewsAPI**: ニュースAPI
+        - **Hybrid**: CSEとNewsAPIの複合検索
         """)
         
         # 追加の検索制御

--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import List, Optional, Union, Dict, Any
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 class SalesType(str, Enum):
     HUNTER = "hunter"  # 🏹 ハンター
@@ -23,6 +23,7 @@ class SearchProvider(str, Enum):
     CSE = "cse"
     NEWSAPI = "newsapi"
     STUB = "stub"
+    HYBRID = "hybrid"
 
 class AppSettings(BaseModel):
     """アプリケーション設定"""
@@ -51,6 +52,17 @@ class AppSettings(BaseModel):
     # カスタマイズ設定
     custom_prompts: Dict[str, str] = Field(default_factory=dict, description="カスタムプロンプト")
     sales_type_colors: Dict[str, str] = Field(default_factory=dict, description="営業タイプ別の色設定")
+
+    @field_validator("search_provider", mode="before")
+    @classmethod
+    def _validate_search_provider(cls, v: Any) -> SearchProvider:
+        """検索プロバイダーの値を検証し、不正値はSTUBにフォールバック"""
+        if isinstance(v, SearchProvider):
+            return v
+        try:
+            return SearchProvider(str(v))
+        except Exception:
+            return SearchProvider.STUB
 
 class SalesInput(BaseModel):
     sales_type: SalesType

--- a/services/settings_manager.py
+++ b/services/settings_manager.py
@@ -50,8 +50,13 @@ class SettingsManager:
     def update_setting(self, key: str, value: Any) -> bool:
         """特定の設定を更新"""
         settings = self.load_settings()
-        
+
         if hasattr(settings, key):
+            if key == "search_provider":
+                try:
+                    value = SearchProvider(value)
+                except Exception:
+                    value = SearchProvider.STUB
             setattr(settings, key, value)
             return self.save_settings(settings)
         return False

--- a/tests/test_settings_manager.py
+++ b/tests/test_settings_manager.py
@@ -223,6 +223,25 @@ class TestSettingsManager:
         assert "limit" in search_config
         assert search_config["provider"] == SearchProvider.STUB
         assert search_config["limit"] == 5
+
+    def test_hybrid_search_provider_persistence(self):
+        """hybridプロバイダー設定の永続化テスト"""
+        # 事前にhybrid設定をファイルに保存
+        settings = AppSettings(search_provider=SearchProvider.HYBRID)
+        self.settings_manager.save_settings(settings)
+
+        # 設定を読み込みhybridが適用されることを確認
+        loaded = self.settings_manager.load_settings()
+        assert loaded.search_provider == SearchProvider.HYBRID
+
+        # 新しいインスタンスで再読込し、設定が保持されていることを確認
+        new_manager = SettingsManager(str(self.config_file))
+        reloaded = new_manager.load_settings()
+        assert reloaded.search_provider == SearchProvider.HYBRID
+
+        # get_search_configでもhybridが取得されることを確認
+        search_config = new_manager.get_search_config()
+        assert search_config["provider"] == SearchProvider.HYBRID
     
     def test_get_ui_config(self):
         """UI設定の取得テスト"""


### PR DESCRIPTION
## Summary
- support `hybrid` search provider in core models with validation fallback
- allow settings manager to sanitize search provider values
- expose Hybrid option in settings UI and test configuration persistence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0e023d27c8333b8fee1fcd808cb4d