### PR TITLE
feat: enforce strict json schema for openai

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ CSE_API_KEY=
 CSE_CX=
 ```
 
+## LLMプロバイダのJSONスキーマ対応
+
+`OpenAIProvider.call_llm` に `json_schema` を渡すと、OpenAI API は
+`response_format={"type": "json_schema", "json_schema": schema, "strict": True}`
+を利用して呼び出されます。スキーマに合わない応答は `ValueError`
+として扱われ、呼び出し元で検知できます。
+
 ## テスト
 
 ```bash

--- a/providers/llm_openai.py
+++ b/providers/llm_openai.py
@@ -81,9 +81,13 @@ class OpenAIProvider:
             if "top_p" in mode_config:
                 request_params["top_p"] = mode_config["top_p"]
             
-            # JSONスキーマが指定されている場合
+            # JSONスキーマが指定されている場合は厳密な検証を有効化
             if json_schema:
-                request_params["response_format"] = {"type": "json_object"}
+                request_params["response_format"] = {
+                    "type": "json_schema",
+                    "json_schema": json_schema,
+                    "strict": True,
+                }
             
             response = self.client.chat.completions.create(**request_params)
             

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -91,9 +91,13 @@ class TestOpenAIProvider:
                 provider = OpenAIProvider()
                 schema = {"type": "object", "required": ["structured"]}
                 result = provider.call_llm("構造化プロンプト", "creative", schema)
-                
+
                 call_args = mock_client.chat.completions.create.call_args[1]
-                assert call_args["response_format"] == {"type": "json_object"}
+                assert call_args["response_format"] == {
+                    "type": "json_schema",
+                    "json_schema": schema,
+                    "strict": True,
+                }
                 
                 # JSONスキーマ指定時は直接パースされたレスポンスが返される
                 assert result == {"structured": "data"}
@@ -159,9 +163,16 @@ class TestOpenAIProvider:
                 
                 provider = OpenAIProvider()
                 schema = {"type": "object", "required": ["field1", "field2"]}
-                
+
                 with pytest.raises(ValueError, match="LLMの応答が期待されるスキーマに従っていません"):
                     provider.call_llm("プロンプト", "speed", schema)
+
+                call_args = mock_client.chat.completions.create.call_args[1]
+                assert call_args["response_format"] == {
+                    "type": "json_schema",
+                    "json_schema": schema,
+                    "strict": True,
+                }
     
     def test_validate_schema(self):
         """スキーマ検証のテスト"""


### PR DESCRIPTION
## Summary
- enforce strict OpenAI json schema responses in provider
- assert strict response_format and schema violation behavior in tests
- document json schema strictness in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0e30f74a08333983ada801b4896a4