### PR TITLE
test: add regression for polite fallback phrase

### DIFF
--- a/services/icebreaker.py
+++ b/services/icebreaker.py
@@ -117,6 +117,7 @@ class IcebreakerService:
     def _generate_fallback_icebreakers(self, sales_type: SalesType, industry: str, tone: str) -> List[str]:
         """フォールバック用のアイスブレイクを生成"""
         # 営業タイプと業界に応じた基本的なアイスブレイク
+        # "お聞かせください" is the correct polite phrase. Avoid the typo "お聞かください".
         fallback_templates = {
             SalesType.HUNTER: [
                 f"最近の{industry}業界の動向はいかがですか？",

--- a/tests/test_icebreaker.py
+++ b/tests/test_icebreaker.py
@@ -121,6 +121,11 @@ class TestIcebreakerService:
             assert len(result) == 3
             # フォールバックでは業界名が含まれることを確認
             assert any("IT" in icebreaker for icebreaker in result)
+
+    def test_fallback_contains_polite_phrase(self):
+        """フォールバック文言の敬語を検証"""
+        result = self.service._generate_fallback_icebreakers(SalesType.CONSULTANT, "IT", "一般的")
+        assert any("お聞かせください" in icebreaker for icebreaker in result)
     
     def test_get_icebreaker_schema(self):
         """アイスブレイクスキーマの取得テスト"""


### PR DESCRIPTION
## Summary
- clarify in icebreaker fallback that `お聞かせください` is the intended phrase
- test that fallback icebreakers include the polite expression

## Testing
- `codespell services/icebreaker.py tests/test_icebreaker.py`
- `pytest tests/test_icebreaker.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0ef2977c88333831c1213baeb5f6c