### PR TITLE
Improve URL validation with validators library

### DIFF
--- a/core/validation.py
+++ b/core/validation.py
@@ -1,5 +1,6 @@
 from typing import Optional, List
 from urllib.parse import urlparse
+import validators
 from .models import SalesInput, SalesType
 
 def validate_url(url: str) -> bool:
@@ -7,16 +8,14 @@ def validate_url(url: str) -> bool:
     if not url:
         return False
     try:
-        result = urlparse(url)
-        # サポートするスキームのみ許可
-        supported_schemes = ['http', 'https']
-        
-        # 各条件を個別にチェック
-        scheme_valid = result.scheme in supported_schemes
-        netloc_exists = bool(result.netloc)
-        netloc_length_valid = len(result.netloc) > 0
-        
-        return scheme_valid and netloc_exists and netloc_length_valid
+        parsed = urlparse(url)
+        # スキームは http/https のみ許可
+        if parsed.scheme not in {"http", "https"}:
+            return False
+        if not parsed.netloc:
+            return False
+        # validators.url は True か ValidationError を返す
+        return validators.url(url) is True
     except Exception:
         return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ streamlit-sortables>=0.2.0
 PyYAML>=6.0
 
 jsonschema>=4.0
+validators>=0.20

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -29,6 +29,8 @@ class TestURLValidation:
             "example.com",  # スキームなし
             "https://",  # ホストなし
             "http://",  # ホストなし
+            "https://exa_mple.com",  # 無効なホスト名
+            "https://example.com/invalid path",  # パスに空白
         ]
         
         for url in invalid_urls:


### PR DESCRIPTION
## Summary
- enhance URL validator to verify scheme, hostname, and path using `validators`
- add invalid URL unit tests for malformed hostnames and paths
- include `validators` dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b12892f46483339c6e17e60b7d5b6f