### PR TITLE
feat: add GCS storage provider

### DIFF
--- a/app/pages/history.py
+++ b/app/pages/history.py
@@ -3,7 +3,7 @@ import math
 import streamlit as st
 from typing import Any, Dict, List
 from urllib.parse import urlparse
-from providers.storage_local import LocalStorageProvider
+from services.storage_service import get_storage_provider
 from core.models import SalesType
 from streamlit_sortables import sort_items
 
@@ -12,7 +12,7 @@ def show_history_page() -> None:
     st.header("履歴（セッション一覧）")
     st.write("保存された生成結果を参照・再利用できます。")
 
-    provider = LocalStorageProvider(data_dir="./data")
+    provider = get_storage_provider()
 
     # フィルタUI
     with st.expander("フィルタ", expanded=True):
@@ -41,7 +41,7 @@ def show_history_page() -> None:
             page_size = st.selectbox("表示件数", options=[5, 10, 20, 50], index=[5,10,20,50].index(default_size), key="history_page_size")
         with s3:
             # 既存タグ/ドメインを収集してサジェスト
-            provider_tmp = LocalStorageProvider(data_dir="./data")
+            provider_tmp = get_storage_provider()
             sessions_for_tags: List[Dict[str, Any]] = provider_tmp.list_sessions()
             all_tags: set[str] = set()
             all_domains: set[str] = set()
@@ -193,14 +193,14 @@ def show_history_page() -> None:
             st.experimental_rerun()
     with top_c4:
         if st.button("📌 選択をピン留め", key="pin_sel_top") and selected_ids:
-            provider = LocalStorageProvider(data_dir="./data")
+            provider = get_storage_provider()
             for sid in selected_ids:
                 provider.set_pinned(sid, True)
             st.success("ピン留めを更新しました")
             st.experimental_rerun()
     with top_c5:
         if st.button("📌 選択のピン解除", key="unpin_sel_top") and selected_ids:
-            provider = LocalStorageProvider(data_dir="./data")
+            provider = get_storage_provider()
             for sid in selected_ids:
                 provider.set_pinned(sid, False)
             st.success("ピン解除を更新しました")
@@ -292,7 +292,7 @@ def show_history_page() -> None:
             reordered_tags = [it["header"] for it in reordered] if reordered else current_tags
             tag_cols = st.columns([2, 1])
             # 最新の全タグ候補を取得
-            provider_tags = LocalStorageProvider(data_dir="./data")
+            provider_tags = get_storage_provider()
             sessions_tags: List[Dict[str, Any]] = provider_tags.list_sessions()
             all_tags_now: set[str] = set()
             for s2 in sessions_tags:
@@ -313,7 +313,7 @@ def show_history_page() -> None:
                     key=f"tag_new_{sess_id}"
                 )
             if st.button("💾 タグを更新", key=f"save_tags_{sess_id}"):
-                provider_save = LocalStorageProvider(data_dir="./data")
+                provider_save = get_storage_provider()
                 new_tags = [t.strip() for t in (new_tags_str or "").split(",") if t.strip()]
                 merged = list(dict.fromkeys([*reordered_tags, *selected_existing, *new_tags]))
                 ok = provider_save.update_tags(sess_id, merged)
@@ -370,7 +370,7 @@ def show_history_page() -> None:
                 pinned = bool(meta.get("pinned", False))
                 pin_label = "📌 ピン解除" if pinned else "📌 ピン留め"
                 if st.button(pin_label, key=f"pin_{sess_id}"):
-                    provider = LocalStorageProvider(data_dir="./data")
+                    provider = get_storage_provider()
                     provider.set_pinned(sess_id, not pinned)
                     st.experimental_rerun()
             with a_col4:
@@ -390,7 +390,7 @@ def show_history_page() -> None:
                     c1, c2 = st.columns(2)
                     with c1:
                         if st.button("はい、削除する", key=f"confirm_yes_{sess_id}"):
-                            provider = LocalStorageProvider(data_dir="./data")
+                            provider = get_storage_provider()
                             ok = provider.delete_session(sess_id)
                             st.session_state["confirm_delete"] = None
                             if ok:
@@ -426,14 +426,14 @@ def show_history_page() -> None:
             st.experimental_rerun()
     with bot_c4:
         if st.button("📌 選択をピン留め", key="pin_sel_bottom") and selected_ids:
-            provider = LocalStorageProvider(data_dir="./data")
+            provider = get_storage_provider()
             for sid in selected_ids:
                 provider.set_pinned(sid, True)
             st.success("ピン留めを更新しました")
             st.experimental_rerun()
     with bot_c5:
         if st.button("📌 選択のピン解除", key="unpin_sel_bottom") and selected_ids:
-            provider = LocalStorageProvider(data_dir="./data")
+            provider = get_storage_provider()
             for sid in selected_ids:
                 provider.set_pinned(sid, False)
             st.success("ピン解除を更新しました")
@@ -448,7 +448,7 @@ def show_history_page() -> None:
         bc1, bc2 = st.columns(2)
         with bc1:
             if st.button("はい、削除する", key="batch_del_yes"):
-                provider = LocalStorageProvider(data_dir="./data")
+                provider = get_storage_provider()
                 ok_count = 0
                 for sid in list(selected_ids):
                     if provider.delete_session(sid):

--- a/app/pages/icebreaker.py
+++ b/app/pages/icebreaker.py
@@ -275,37 +275,30 @@ def save_icebreakers(sales_type: SalesType, industry: str, icebreakers: list, co
         # 成功メッセージ
         st.success(f"アイスブレイクをセッションに保存しました！セッションID: {session_id[:8]}...")
         
-        # 履歴ページで表示できるように、LocalStorageProviderにも保存
+        # 履歴ページで表示できるように保存
         try:
-            from providers.storage_local import LocalStorageProvider
-            provider = LocalStorageProvider(data_dir="./data")
-            
-            # 入力データと出力データを分けて保存
-            input_data = {
-                "sales_type": sales_type.value,
-                "industry": industry,
-                "company_hint": company_hint,
-                "search_enabled": search_enabled
-            }
-            
-            output_data = {
+            from services.storage_service import get_storage_provider
+
+            provider = get_storage_provider()
+            payload = {
                 "type": "icebreaker",
-                "icebreakers": icebreakers,
-                "emoji": get_sales_type_emoji(sales_type),
-                "sales_type": sales_type.value,
-                "industry": industry
+                "input": {
+                    "sales_type": sales_type.value,
+                    "industry": industry,
+                    "company_hint": company_hint,
+                    "search_enabled": search_enabled,
+                },
+                "output": {
+                    "icebreakers": icebreakers,
+                    "emoji": get_sales_type_emoji(sales_type),
+                    "sales_type": sales_type.value,
+                    "industry": industry,
+                },
             }
-            
-            # セッションを保存
-            provider.save_session(
-                session_id=session_id,
-                input_data=input_data,
-                output_data=output_data,
-                tags=[f"{sales_type.value}", f"{industry}業界"]
-            )
-            
+            provider.save_session(payload, session_id=session_id)
+            provider.update_tags(session_id, [f"{sales_type.value}", f"{industry}業界"])
             st.success("履歴にも保存しました！履歴ページで確認できます。")
-            
+
         except Exception as storage_error:
             st.warning(f"履歴への保存に失敗しました: {storage_error}")
         

--- a/app/pages/post_review.py
+++ b/app/pages/post_review.py
@@ -7,7 +7,7 @@ from typing import List
 from core.models import SalesType
 from services.post_analyzer import PostAnalyzerService
 from services.settings_manager import SettingsManager
-from providers.storage_local import LocalStorageProvider
+from services.storage_service import get_storage_provider
 from datetime import datetime
 from components.sales_type import sales_type_selectbox
 from components.copy_button import copy_button
@@ -328,7 +328,7 @@ def display_analysis_result(analysis: dict):
 def save_post_review(**kwargs) -> str:
     """商談後ふりかえり解析の結果をセッション形式で保存し、Session IDを返す"""
     try:
-        provider = LocalStorageProvider(data_dir="./data")
+        provider = get_storage_provider()
         payload = {
             "type": "post_review",
             "input": {

--- a/app/pages/pre_advice.py
+++ b/app/pages/pre_advice.py
@@ -12,7 +12,6 @@ from core.validation import (
     validate_purpose,
     validate_sales_input,
 )
-from providers.storage_local import LocalStorageProvider
 from services.icebreaker import IcebreakerService
 from services.pre_advisor import PreAdvisorService
 
@@ -1548,7 +1547,9 @@ def display_advice(advice: dict):
 def save_pre_advice(*, sales_input: SalesInput, advice: dict, selected_icebreaker: str | None) -> str:
     """事前アドバイスの結果をセッション形式で保存し、Session IDを返す"""
     try:
-        provider = LocalStorageProvider(data_dir="./data")
+        from services.storage_service import get_storage_provider
+
+        provider = get_storage_provider()
         payload = {
             "type": "pre_advice",
             "input": sales_input.dict(),

--- a/app/pages/search_enhancement.py
+++ b/app/pages/search_enhancement.py
@@ -8,7 +8,7 @@ import json
 from datetime import datetime
 from services.search_enhancer import SearchEnhancerService
 from services.settings_manager import SettingsManager
-from providers.storage_local import LocalStorageProvider
+from services.storage_service import get_storage_provider
 
 def main():
     st.set_page_config(
@@ -24,7 +24,7 @@ def main():
     try:
         settings_manager = SettingsManager()
         search_enhancer = SearchEnhancerService(settings_manager)
-        storage_provider = LocalStorageProvider()
+        storage_provider = get_storage_provider()
     except Exception as e:
         st.error(f"サービスの初期化に失敗しました: {e}")
         return
@@ -587,7 +587,7 @@ def show_enhanced_search(search_enhancer, industry, purpose, num_results):
 def save_optimization_result(original_query, result, industry, purpose):
     """最適化結果の保存"""
     try:
-        storage_provider = LocalStorageProvider()
+        storage_provider = get_storage_provider()
         
         session_data = {
             "type": "query_optimization",
@@ -610,7 +610,7 @@ def save_optimization_result(original_query, result, industry, purpose):
 def save_enhanced_search_result(result, industry, purpose):
     """高度化検索結果の保存"""
     try:
-        storage_provider = LocalStorageProvider()
+        storage_provider = get_storage_provider()
         
         # 保存データの作成
         data = {

--- a/env.example
+++ b/env.example
@@ -1,6 +1,9 @@
 APP_ENV=local
 OPENAI_API_KEY=sk-xxxx
 DATA_DIR=./data
+STORAGE_PROVIDER=local  # local|gcs
+GCS_BUCKET_NAME=
+GCS_PREFIX=sessions
 SEARCH_PROVIDER=none   # none|cse|newsapi 等
 CSE_API_KEY=
 CSE_CX=

--- a/providers/storage_gcs.py
+++ b/providers/storage_gcs.py
@@ -1,0 +1,127 @@
+import json
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List
+import os
+
+from google.cloud import storage
+
+
+class GCSStorageProvider:
+    """Google Cloud Storage based session storage provider"""
+
+    def __init__(self, bucket_name: str, prefix: str = "sessions") -> None:
+        if not bucket_name:
+            raise ValueError("bucket_name is required")
+        self.client = storage.Client()
+        self.bucket = self.client.bucket(bucket_name)
+        self.prefix = prefix.rstrip("/") + "/"
+
+    def _blob(self, session_id: str):
+        return self.bucket.blob(f"{self.prefix}{session_id}.json")
+
+    def save_session(self, data: Dict[str, Any], session_id: str | None = None) -> str:
+        """Save session data to GCS"""
+        if session_id is None:
+            session_id = str(uuid.uuid4())
+
+        blob = self._blob(session_id)
+        data_with_metadata = {
+            "session_id": session_id,
+            "created_at": datetime.now().isoformat(),
+            "pinned": False,
+            "tags": [],
+            "data": data,
+        }
+        blob.upload_from_string(
+            json.dumps(data_with_metadata, ensure_ascii=False, indent=2),
+            content_type="application/json",
+        )
+        return session_id
+
+    def load_session(self, session_id: str) -> Dict[str, Any]:
+        """Load a session by id"""
+        blob = self._blob(session_id)
+        if not blob.exists():
+            raise FileNotFoundError(f"session {session_id} not found")
+        content = blob.download_as_text()
+        return json.loads(content)
+
+    def list_sessions(self) -> List[Dict[str, Any]]:
+        """List all sessions"""
+        sessions: List[Dict[str, Any]] = []
+        for blob in self.client.list_blobs(self.bucket, prefix=self.prefix):
+            if not blob.name.endswith(".json"):
+                continue
+            try:
+                content = blob.download_as_text()
+                sessions.append(json.loads(content))
+            except Exception:
+                continue
+        return sorted(
+            sessions,
+            key=lambda x: (
+                x.get("pinned", False),
+                x.get("created_at", ""),
+            ),
+            reverse=True,
+        )
+
+    def delete_session(self, session_id: str) -> bool:
+        """Delete a session"""
+        blob = self._blob(session_id)
+        if not blob.exists():
+            return False
+        blob.delete()
+        return True
+
+    def set_pinned(self, session_id: str, pinned: bool) -> bool:
+        """Update pinned state"""
+        blob = self._blob(session_id)
+        if not blob.exists():
+            return False
+        try:
+            content = json.loads(blob.download_as_text())
+            content["pinned"] = bool(pinned)
+            blob.upload_from_string(
+                json.dumps(content, ensure_ascii=False, indent=2),
+                content_type="application/json",
+            )
+            return True
+        except Exception:
+            return False
+
+    def update_tags(self, session_id: str, tags: List[str]) -> bool:
+        """Overwrite tags"""
+        blob = self._blob(session_id)
+        if not blob.exists():
+            return False
+        try:
+            content = json.loads(blob.download_as_text())
+            normalized: List[str] = []
+            seen = set()
+            for t in tags:
+                if not isinstance(t, str):
+                    continue
+                name = t.strip()
+                if not name or name in seen:
+                    continue
+                seen.add(name)
+                normalized.append(name)
+            content["tags"] = normalized
+            blob.upload_from_string(
+                json.dumps(content, ensure_ascii=False, indent=2),
+                content_type="application/json",
+            )
+            return True
+        except Exception:
+            return False
+
+    def save_data(self, filename: str, data: Dict[str, Any]) -> str:
+        """Save arbitrary data file"""
+        blob = self.bucket.blob(f"{self.prefix}{filename}")
+        blob.upload_from_string(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            content_type="application/json",
+        )
+        return filename

--- a/providers/storage_local.py
+++ b/providers/storage_local.py
@@ -116,3 +116,11 @@ class LocalStorageProvider:
         except Exception:
             return False
 
+    def save_data(self, filename: str, data: Dict[str, Any]) -> str:
+        """任意データをファイルに保存"""
+        file_path = self.data_dir / filename
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(file_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        return filename
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ PyYAML>=6.0
 
 jsonschema>=4.0
 validators>=0.20
+google-cloud-storage>=2.16

--- a/services/storage_service.py
+++ b/services/storage_service.py
@@ -1,0 +1,29 @@
+import os
+from providers.storage_local import LocalStorageProvider
+
+try:
+    from providers.storage_gcs import GCSStorageProvider  # type: ignore
+except Exception:  # pragma: no cover
+    GCSStorageProvider = None
+
+
+def get_storage_provider():
+    """Return storage provider based on environment"""
+    app_env = os.getenv("APP_ENV", "local")
+    provider_name = os.getenv("STORAGE_PROVIDER")
+    if provider_name:
+        provider = provider_name
+    elif app_env != "local":
+        provider = "gcs"
+    else:
+        provider = "local"
+
+    if provider == "gcs":
+        if GCSStorageProvider is None:
+            raise RuntimeError("GCSStorageProvider not available")
+        bucket = os.getenv("GCS_BUCKET_NAME")
+        prefix = os.getenv("GCS_PREFIX", "sessions")
+        return GCSStorageProvider(bucket_name=bucket, prefix=prefix)
+
+    data_dir = os.getenv("DATA_DIR", "./data")
+    return LocalStorageProvider(data_dir=data_dir)


### PR DESCRIPTION
## Summary
- add Google Cloud Storage provider implementing LocalStorageProvider API
- select storage provider based on environment
- wire pages to use provider factory and document env variables

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b135c2ca588333bbff09d06d894b16