### PR TITLE
feat: add user-aware session history

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -114,3 +114,19 @@
 - `pytest -q` で 82 件のテストが成功
 - Environment: Python 3.12.10, streamlit==1.49.0, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0
 
+## 2025-09-03
+### Task
+- ローカル保存セッションに `user_id` と `success` を付与し、履歴ページにユーザー別フィルタと集計ダッシュボードを追加
+  - refs: [providers/storage_local.py, app/pages/history.py]
+
+### Reviews
+1. **Python上級エンジニア視点**: メタデータ付与とフィルタ処理が関数化され、拡張に耐える設計になった。
+2. **UI/UX専門家視点**: ユーザー別に履歴を見分けられるようになり、簡易メトリクスで進捗が即座に把握できる。
+3. **クラウドエンジニア視点**: `user_id` の保存で将来のマルチテナント移行時の分離基盤が整った。
+4. **ユーザー視点**: 自分の履歴を素早く確認でき、成功率の可視化で成果が実感しやすい。
+
+### Testing
+- `pytest -q` を実行（結果は下記参照）
+- Environment: Python 3.12.10, streamlit==1.49.0, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0
+
+

--- a/providers/storage_local.py
+++ b/providers/storage_local.py
@@ -12,23 +12,36 @@ class LocalStorageProvider:
         self.sessions_dir = self.data_dir / "sessions"
         self.sessions_dir.mkdir(exist_ok=True)
     
-    def save_session(self, data: Dict[str, Any], session_id: str = None) -> str:
+    def save_session(
+        self,
+        data: Dict[str, Any],
+        session_id: str | None = None,
+        user_id: str | None = None,
+        success: bool | None = None,
+    ) -> str:
         """セッションデータを保存"""
         if session_id is None:
             session_id = str(uuid.uuid4())
-        
+
+        if user_id is None:
+            user_id = os.getenv("USER_ID", "anonymous")
+        if success is None:
+            success = data.get("success", True)
+
         file_path = self.sessions_dir / f"{session_id}.json"
         data_with_metadata = {
             "session_id": session_id,
+            "user_id": user_id,
             "created_at": datetime.now().isoformat(),
+            "success": bool(success),
             "pinned": False,
             "tags": [],
-            "data": data
+            "data": data,
         }
-        
-        with open(file_path, 'w', encoding='utf-8') as f:
+
+        with open(file_path, "w", encoding="utf-8") as f:
             json.dump(data_with_metadata, f, ensure_ascii=False, indent=2)
-        
+
         return session_id
     
     def load_session(self, session_id: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- record `user_id` and `success` when saving sessions
- filter history by user and show counts and success rate
- log work in WORKLOG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1430170588333a30e7fe158239bb6