### PR TITLE
feat: add mobile tab navigation

### DIFF
--- a/app/pages/pre_advice.py
+++ b/app/pages/pre_advice.py
@@ -587,13 +587,22 @@ def show_pre_advice_page():
     st.header("事前アドバイス生成")
     st.write("商談前の準備をサポートします。営業タイプ、業界、商品情報を入力してください。")
 
+    is_mobile = st.session_state.get("screen_width", 1000) < 700
+
     if st.session_state.get("quickstart_mode"):
         submitted, form_data = render_quickstart_form()
     else:
         if "pre_advice_form_data" not in st.session_state:
             st.session_state.pre_advice_form_data = {}
-        submitted, form_data = render_pre_advice_form()
-        render_icebreaker_section()
+        if is_mobile:
+            tab_form, tab_ice = st.tabs(["入力フォーム", "アイスブレイク"])
+            with tab_form:
+                submitted, form_data = render_pre_advice_form()
+            with tab_ice:
+                render_icebreaker_section()
+        else:
+            submitted, form_data = render_pre_advice_form()
+            render_icebreaker_section()
 
     autorun = st.session_state.pop("pre_advice_autorun", False)
     if submitted or autorun:

--- a/app/ui.py
+++ b/app/ui.py
@@ -1,17 +1,19 @@
-import streamlit as st
 import os
+import streamlit as st
 from dotenv import load_dotenv
 
 # 環境変数を読み込み
 load_dotenv()
 
+
 def main():
     st.set_page_config(
         page_title="営業特化SaaS",
         page_icon="🏢",
-        layout="wide"
+        layout="wide",
     )
-    # モバイルUI最適化（シンプルなレスポンシブCSS）
+
+    # モバイルUI最適化（レスポンシブCSS + サイドバー非表示）
     st.markdown(
         """
         <style>
@@ -19,6 +21,7 @@ def main():
           .block-container { padding-left: 0.6rem; padding-right: 0.6rem; }
           .stButton>button { width: 100%; }
           .stTextInput>div>div>input, textarea, select { font-size: 16px; }
+          section[data-testid="stSidebar"] { display: none; }
         }
         </style>
         """,
@@ -47,57 +50,107 @@ def main():
         unsafe_allow_html=True,
     )
     st.text_input("", key="screen_width")
-    
+
     st.title("🏢 営業特化SaaS")
     st.markdown("---")
-    
-    # サイドバー
-    st.sidebar.title("メニュー")
-    # セッションでページ切替に対応
-    if "page_select" not in st.session_state:
-        st.session_state.page_select = "事前アドバイス生成"
 
-    page = st.sidebar.selectbox(
-        "ページを選択",
-        ["事前アドバイス生成", "商談後ふりかえり解析", "アイスブレイク生成", "履歴", "設定・カスタマイズ", "検索機能の高度化"],
-        key="page_select"
-    )
+    is_mobile = st.session_state.get("screen_width", 1000) < 700
 
-    # クイックスタートモードの切り替え
-    st.sidebar.checkbox(
-        "クイックスタートモード",
-        help="必要最小限の入力項目のみ表示",
-        key="quickstart_mode",
-    )
-    
     # 環境変数の確認
     if not os.getenv("OPENAI_API_KEY"):
         st.warning("⚠️ OPENAI_API_KEYが設定されていません。一部機能が制限されます。")
-    
-    # ページ表示
-    if page == "事前アドバイス生成":
-        from pages.pre_advice import show_pre_advice_page
-        show_pre_advice_page()
-        
-    elif page == "商談後ふりかえり解析":
-        from pages.post_review import show_post_review_page
-        show_post_review_page()
-        
-    elif page == "アイスブレイク生成":
-        from pages.icebreaker import show_icebreaker_page
-        show_icebreaker_page()
-        
-    elif page == "設定・カスタマイズ":
-        from pages.settings import show_settings_page
-        show_settings_page()
 
-    elif page == "履歴":
-        from pages.history import show_history_page
-        show_history_page()
-        
-    elif page == "検索機能の高度化":
-        from pages.search_enhancement import show_enhanced_search_page
-        show_enhanced_search_page()
+    if is_mobile:
+        # サイドバーの代わりにタブでページ切り替え
+        st.checkbox(
+            "クイックスタートモード",
+            help="必要最小限の入力項目のみ表示",
+            key="quickstart_mode",
+        )
+        tabs = st.tabs(
+            [
+                "事前アドバイス生成",
+                "商談後ふりかえり解析",
+                "アイスブレイク生成",
+                "履歴",
+                "設定・カスタマイズ",
+                "検索機能の高度化",
+            ]
+        )
+        with tabs[0]:
+            from pages.pre_advice import show_pre_advice_page
+
+            show_pre_advice_page()
+        with tabs[1]:
+            from pages.post_review import show_post_review_page
+
+            show_post_review_page()
+        with tabs[2]:
+            from pages.icebreaker import show_icebreaker_page
+
+            show_icebreaker_page()
+        with tabs[3]:
+            from pages.history import show_history_page
+
+            show_history_page()
+        with tabs[4]:
+            from pages.settings import show_settings_page
+
+            show_settings_page()
+        with tabs[5]:
+            from pages.search_enhancement import show_enhanced_search_page
+
+            show_enhanced_search_page()
+    else:
+        # デスクトップでは従来どおりサイドバーを使用
+        st.sidebar.title("メニュー")
+        if "page_select" not in st.session_state:
+            st.session_state.page_select = "事前アドバイス生成"
+
+        page = st.sidebar.selectbox(
+            "ページを選択",
+            [
+                "事前アドバイス生成",
+                "商談後ふりかえり解析",
+                "アイスブレイク生成",
+                "履歴",
+                "設定・カスタマイズ",
+                "検索機能の高度化",
+            ],
+            key="page_select",
+        )
+
+        st.sidebar.checkbox(
+            "クイックスタートモード",
+            help="必要最小限の入力項目のみ表示",
+            key="quickstart_mode",
+        )
+
+        if page == "事前アドバイス生成":
+            from pages.pre_advice import show_pre_advice_page
+
+            show_pre_advice_page()
+        elif page == "商談後ふりかえり解析":
+            from pages.post_review import show_post_review_page
+
+            show_post_review_page()
+        elif page == "アイスブレイク生成":
+            from pages.icebreaker import show_icebreaker_page
+
+            show_icebreaker_page()
+        elif page == "設定・カスタマイズ":
+            from pages.settings import show_settings_page
+
+            show_settings_page()
+        elif page == "履歴":
+            from pages.history import show_history_page
+
+            show_history_page()
+        elif page == "検索機能の高度化":
+            from pages.search_enhancement import show_enhanced_search_page
+
+            show_enhanced_search_page()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- hide sidebar on narrow screens with responsive CSS
- switch mobile navigation to tabs and add mobile-friendly form/icebreak tabs

## Testing
- `pip install validators`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b14879fff88333866a4fffdcb067f2