### PR TITLE
feat: make OpenAI model configurable

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -28,6 +28,7 @@ class SearchProvider(str, Enum):
 class AppSettings(BaseModel):
     """アプリケーション設定"""
     # LLM設定
+    openai_model: str = Field(default="gpt-4o-mini", description="OpenAIモデル名")
     default_llm_mode: LLMMode = Field(default=LLMMode.SPEED, description="デフォルトのLLMモード")
     max_tokens: int = Field(default=1000, ge=100, le=4000, description="最大トークン数")
     temperature: float = Field(default=0.7, ge=0.0, le=2.0, description="創造性（温度）")

--- a/env.example
+++ b/env.example
@@ -1,5 +1,6 @@
 APP_ENV=local
 OPENAI_API_KEY=sk-xxxx
+OPENAI_MODEL=gpt-4o-mini
 DATA_DIR=./data
 STORAGE_PROVIDER=local  # local|gcs
 GCS_BUCKET_NAME=

--- a/providers/llm_openai.py
+++ b/providers/llm_openai.py
@@ -87,10 +87,20 @@ class OpenAIProvider:
             system_message = "あなたは日本のトップ営業コーチです。"
             if json_schema:
                 system_message += "指定されたJSONスキーマに厳密に従って回答してください。"
-            
+
             # リクエストパラメータを構築
+            model_name = os.getenv("OPENAI_MODEL")
+            if not model_name and self.settings_manager:
+                try:
+                    settings = self.settings_manager.load_settings()
+                    model_name = getattr(settings, "openai_model", None)
+                except Exception:
+                    model_name = None
+            if not model_name:
+                model_name = "gpt-4o-mini"
+
             request_params = {
-                "model": "gpt-4o-mini",
+                "model": model_name,
                 "messages": [
                     {"role": "system", "content": system_message},
                     {"role": "user", "content": prompt}

--- a/services/settings_manager.py
+++ b/services/settings_manager.py
@@ -99,7 +99,8 @@ class SettingsManager:
         return {
             "mode": settings.default_llm_mode,
             "max_tokens": settings.max_tokens,
-            "temperature": settings.temperature
+            "temperature": settings.temperature,
+            "model": settings.openai_model,
         }
     
     def get_search_config(self) -> Dict[str, Any]:

--- a/tests/test_settings_manager.py
+++ b/tests/test_settings_manager.py
@@ -28,8 +28,9 @@ class TestSettingsManager:
     def test_load_settings_new_file(self):
         """新規設定ファイルの読み込みテスト"""
         settings = self.settings_manager.load_settings()
-        
+
         assert isinstance(settings, AppSettings)
+        assert settings.openai_model == "gpt-4o-mini"
         assert settings.default_llm_mode == LLMMode.SPEED
         assert settings.max_tokens == 1000
         assert settings.temperature == 0.7
@@ -44,6 +45,7 @@ class TestSettingsManager:
         """既存設定ファイルの読み込みテスト"""
         # テスト用の設定データ
         test_settings = {
+            "openai_model": "gpt-test",
             "default_llm_mode": "deep",
             "max_tokens": 2000,
             "temperature": 0.5,
@@ -60,6 +62,7 @@ class TestSettingsManager:
         # 設定を読み込み
         settings = self.settings_manager.load_settings()
         
+        assert settings.openai_model == "gpt-test"
         assert settings.default_llm_mode == LLMMode.DEEP
         assert settings.max_tokens == 2000
         assert settings.temperature == 0.5
@@ -95,7 +98,8 @@ class TestSettingsManager:
         # 保存された内容を確認
         with open(self.config_file, 'r', encoding='utf-8') as f:
             saved_data = json.load(f)
-        
+
+        assert saved_data["openai_model"] == "gpt-4o-mini"
         assert saved_data["default_llm_mode"] == "creative"
         assert saved_data["max_tokens"] == 1500
         assert saved_data["temperature"] == 0.9
@@ -168,11 +172,13 @@ class TestSettingsManager:
         assert "default_llm_mode" in exported_data
         assert "max_tokens" in exported_data
         assert "temperature" in exported_data
+        assert "openai_model" in exported_data
     
     def test_import_settings(self):
         """設定のインポートテスト"""
         # インポート用の設定データ
         import_data = {
+            "openai_model": "gpt-import",
             "default_llm_mode": "creative",
             "max_tokens": 2500,
             "temperature": 0.6,
@@ -189,6 +195,7 @@ class TestSettingsManager:
         
         # インポートされた設定を確認
         imported_settings = self.settings_manager.load_settings()
+        assert imported_settings.openai_model == "gpt-import"
         assert imported_settings.default_llm_mode == LLMMode.CREATIVE
         assert imported_settings.max_tokens == 2500
         assert imported_settings.temperature == 0.6
@@ -205,13 +212,15 @@ class TestSettingsManager:
         self.settings_manager.load_settings()
         
         llm_config = self.settings_manager.get_llm_config()
-        
+
         assert "mode" in llm_config
         assert "max_tokens" in llm_config
         assert "temperature" in llm_config
+        assert "model" in llm_config
         assert llm_config["mode"] == LLMMode.SPEED
         assert llm_config["max_tokens"] == 1000
         assert llm_config["temperature"] == 0.7
+        assert llm_config["model"] == "gpt-4o-mini"
     
     def test_get_search_config(self):
         """検索設定の取得テスト"""


### PR DESCRIPTION
## Summary
- allow choosing OpenAI model via environment or AppSettings
- expose model in settings manager and example env file
- add tests for model selection and configuration persistence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b14eb86b6c8333b4d3ac930c91061a