### PR TITLE
refactor: escape braces in prompts

### DIFF
--- a/prompts/icebreaker.yaml
+++ b/prompts/icebreaker.yaml
@@ -8,14 +8,14 @@ system: |
   - 商談の導入として適切な内容にする
 
 user_template: |
-  営業タイプ: {sales_type} ({tone})
-  業界: {industry}
-  会社ヒント: {company_hint}
-  
+  営業タイプ: $sales_type ($tone)
+  業界: $industry
+  会社ヒント: $company_hint
+
   業界ニュース:
-  {news_items}
-  
-  上記の情報を基に、{tone}のトーンで1行のアイスブレイクを3つ生成してください。
+  $news_items
+
+  上記の情報を基に、$toneのトーンで1行のアイスブレイクを3つ生成してください。
   各アイスブレイクは自然で親しみやすく、商談の導入として適切な内容にしてください。
 
 output_constraints:

--- a/prompts/pre_advice.yaml
+++ b/prompts/pre_advice.yaml
@@ -10,16 +10,16 @@ system: |
   - 明確なKPIと次アクションを設定
 
 user: |
-  営業タイプ: {sales_type}
-  業界: {industry}
-  商品・サービス: {product}
-  説明: {description}
-  説明URL: {description_url}
-  競合: {competitor}
-  競合URL: {competitor_url}
-  商談ステージ: {stage}
-  目的: {purpose}
-  制約: {constraints}
+  営業タイプ: $sales_type
+  業界: $industry
+  商品・サービス: $product
+  説明: $description
+  説明URL: $description_url
+  競合: $competitor
+  競合URL: $competitor_url
+  商談ステージ: $stage
+  目的: $purpose
+  制約: $constraints
   
   上記の情報を基に、営業担当者の商談前準備をサポートするアドバイスを生成してください。
   

--- a/services/utils.py
+++ b/services/utils.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+def escape_braces(text: str) -> str:
+    """Escape curly braces in the given text for safe formatting.
+
+    This replaces ``{"`` with ``"{{"`` and ``"}"`` with ``"}}"`` so that
+    user provided values containing braces do not interfere with string
+    formatting templates.
+    """
+    if not isinstance(text, str):
+        return text
+    return text.replace("{", "{{").replace("}", "}}")

--- a/tests/test_icebreaker.py
+++ b/tests/test_icebreaker.py
@@ -99,6 +99,23 @@ class TestIcebreakerService:
         assert len(result) == 3
         # フォールバックでは業界名が含まれることを確認
         assert any("IT" in icebreaker for icebreaker in result)
+
+    def test_build_prompt_handles_braces(self):
+        service = self.service
+        service.prompt_template = {
+            "system": "sys",
+            "user_template": "業界: $industry\n会社ヒント: $company_hint",
+            "output_constraints": []
+        }
+        prompt = service._build_prompt(
+            SalesType.HUNTER,
+            industry="I{T}",
+            company_hint="Comp{any}",
+            news_items=[],
+            tone="tone",
+        )
+        assert "I{T}" in prompt
+        assert "Comp{any}" in prompt
     
     def test_get_tone_for_type(self):
         """営業タイプ別トーンの取得テスト"""

--- a/tests/test_pre_advisor.py
+++ b/tests/test_pre_advisor.py
@@ -79,14 +79,14 @@ output_format: "出力形式"
                             
                             # YAMLの戻り値を設定
                             mock_yaml_load.return_value = {
-                                "user": "営業タイプ: {sales_type}\n業界: {industry}",
+                                "user": "営業タイプ: $sales_type\n業界: $industry\n説明: $description",
                                 "system": "システムメッセージ",
                                 "output_format": "出力形式"
                             }
-                            
+
                             service = PreAdvisorService()
                             service.prompt_template = {
-                                "user": "営業タイプ: {sales_type}\n業界: {industry}",
+                                "user": "営業タイプ: $sales_type\n業界: $industry\n説明: $description",
                                 "system": "システムメッセージ",
                                 "output_format": "出力形式"
                             }
@@ -95,7 +95,7 @@ output_format: "出力形式"
                                 sales_type=SalesType.HUNTER,
                                 industry="IT",
                                 product="SaaS",
-                                description="テスト商品",
+                                description="テスト商品{詳細}",
                                 description_url=None,
                                 competitor="競合A",
                                 competitor_url=None,
@@ -107,6 +107,7 @@ output_format: "出力形式"
                             prompt = service._build_prompt(sales_input)
                             assert "営業タイプ: hunter" in prompt
                             assert "業界: IT" in prompt
+                            assert "説明: テスト商品{詳細}" in prompt
                             assert "システムメッセージ" in prompt
                             assert "出力形式" in prompt
     

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,7 @@
+from services.utils import escape_braces
+
+
+def test_escape_braces():
+    assert escape_braces('abc') == 'abc'
+    assert escape_braces('{a}') == '{{a}}'
+    assert escape_braces('a{b}c') == 'a{{b}}c'


### PR DESCRIPTION
## Summary
- escape curly braces in user inputs with new utility
- build prompts using `string.Template` to avoid placeholder conflicts
- add tests for brace escaping

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b15013687c8333a30a1e0b38d4e9c4