### PR TITLE
refactor: rely on pydantic URL validation

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from typing import List, Optional, Union, Dict, Any
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, HttpUrl
 
 class SalesType(str, Enum):
     HUNTER = "hunter"  # 🏹 ハンター
@@ -70,9 +70,9 @@ class SalesInput(BaseModel):
     industry: str
     product: str
     description: Optional[str] = None
-    description_url: Optional[str] = None
+    description_url: HttpUrl | None = None
     competitor: Optional[str] = None
-    competitor_url: Optional[str] = None
+    competitor_url: HttpUrl | None = None
     stage: str
     purpose: str
     constraints: List[str] = Field(default_factory=list)

--- a/core/validation.py
+++ b/core/validation.py
@@ -1,23 +1,5 @@
-from typing import Optional, List
-from urllib.parse import urlparse
-import validators
-from .models import SalesInput, SalesType
-
-def validate_url(url: str) -> bool:
-    """URLの形式を検証"""
-    if not url:
-        return False
-    try:
-        parsed = urlparse(url)
-        # スキームは http/https のみ許可
-        if parsed.scheme not in {"http", "https"}:
-            return False
-        if not parsed.netloc:
-            return False
-        # validators.url は True か ValidationError を返す
-        return validators.url(url) is True
-    except Exception:
-        return False
+from typing import List
+from .models import SalesInput
 
 def validate_sales_input(input_data: SalesInput) -> List[str]:
     """SalesInputの包括的な検証"""
@@ -62,24 +44,17 @@ def validate_xor_fields(input_data: SalesInput) -> List[str]:
     
     # 説明フィールドのXOR検証（入力された場合のみ）
     has_description = bool(input_data.description and input_data.description.strip())
-    has_description_url = bool(input_data.description_url and input_data.description_url.strip())
+    has_description_url = bool(input_data.description_url)
     
     if has_description and has_description_url:
         errors.append("説明はテキストまたはURLのいずれか一方を入力してください")
     
     # 競合フィールドのXOR検証（入力された場合のみ）
     has_competitor = bool(input_data.competitor and input_data.competitor.strip())
-    has_competitor_url = bool(input_data.competitor_url and input_data.competitor_url.strip())
+    has_competitor_url = bool(input_data.competitor_url)
     
     if has_competitor and has_competitor_url:
         errors.append("競合はテキストまたはURLのいずれか一方を入力してください")
-    
-    # URL形式の検証
-    if input_data.description_url and not validate_url(input_data.description_url):
-        errors.append("説明URLの形式が正しくありません")
-    
-    if input_data.competitor_url and not validate_url(input_data.competitor_url):
-        errors.append("競合URLの形式が正しくありません")
     
     return errors
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,5 @@ streamlit-sortables>=0.2.0
 PyYAML>=6.0
 
 jsonschema>=4.0
-validators>=0.20
 google-cloud-storage>=2.16
 google-cloud-secret-manager>=2.20

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,40 +1,54 @@
 import pytest
+from pydantic import ValidationError
 from core.validation import (
-    validate_url, validate_xor_fields, validate_sales_input,
+    validate_xor_fields, validate_sales_input,
     validate_industry, validate_product, validate_stage, validate_purpose
 )
 from core.models import SalesInput, SalesType
 
 class TestURLValidation:
-    """URL検証のテスト"""
-    
+    """PydanticによるURL検証のテスト"""
+
     def test_valid_urls(self):
-        """有効なURLのテスト"""
-        valid_urls = [
-            "https://example.com",
-            "http://test.org",
-            "https://sub.domain.co.jp",
-            "https://example.com/path?param=value"
-        ]
-        
-        for url in valid_urls:
-            assert validate_url(url) == True, f"URL should be valid: {url}"
-    
+        """有効なURLが受理される"""
+        SalesInput(
+            sales_type=SalesType.HUNTER,
+            industry="IT",
+            product="SaaS",
+            description_url="https://example.com",
+            stage="初期接触",
+            purpose="新規顧客獲得"
+        )
+        SalesInput(
+            sales_type=SalesType.HUNTER,
+            industry="IT",
+            product="SaaS",
+            competitor_url="https://competitor.com",
+            stage="初期接触",
+            purpose="新規顧客獲得"
+        )
+
     def test_invalid_urls(self):
-        """無効なURLのテスト"""
-        invalid_urls = [
-            "",
-            "not-a-url",
-            "ftp://example.com",  # サポートしていないスキーム
-            "example.com",  # スキームなし
-            "https://",  # ホストなし
-            "http://",  # ホストなし
-            "https://exa_mple.com",  # 無効なホスト名
-            "https://example.com/invalid path",  # パスに空白
-        ]
-        
-        for url in invalid_urls:
-            assert validate_url(url) == False, f"URL should be invalid: {url}"
+        """無効なURLはValidationErrorを投げる"""
+        with pytest.raises(ValidationError):
+            SalesInput(
+                sales_type=SalesType.HUNTER,
+                industry="IT",
+                product="SaaS",
+                description_url="not-a-url",
+                stage="初期接触",
+                purpose="新規顧客獲得"
+            )
+
+        with pytest.raises(ValidationError):
+            SalesInput(
+                sales_type=SalesType.HUNTER,
+                industry="IT",
+                product="SaaS",
+                competitor_url="not-a-url",
+                stage="初期接触",
+                purpose="新規顧客獲得"
+            )
 
 class TestXORFieldsValidation:
     """XORフィールド検証のテスト"""


### PR DESCRIPTION
## Summary
- use `HttpUrl` for `description_url` and `competitor_url` in `SalesInput`
- remove custom URL validator and simplify XOR checks
- adjust tests to rely on Pydantic URL validation and drop `validators` dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b15264536c8333b917188fdbf3fe71