### PR TITLE
feat: simplify screen width detection

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -1,6 +1,7 @@
 import os
 import streamlit as st
 from dotenv import load_dotenv
+from streamlit_javascript import st_javascript
 
 # 環境変数を読み込み
 load_dotenv()
@@ -30,26 +31,14 @@ def main():
 
     # 画面幅を取得してセッションステートに保存
     if "screen_width" not in st.session_state:
-        st.session_state.screen_width = 1000
-    st.markdown(
-        """
-        <script>
-        function updateScreenWidth() {
-            const width = window.innerWidth;
-            const input = window.parent.document.querySelector('input[id="screen_width"]');
-            if (input) {
-                input.value = width;
-                input.dispatchEvent(new Event('input', { bubbles: true }));
-            }
-        }
-        updateScreenWidth();
-        window.addEventListener('resize', updateScreenWidth);
-        </script>
-        <style>input#screen_width{display:none;}</style>
-        """,
-        unsafe_allow_html=True,
-    )
-    st.text_input("", key="screen_width")
+        width = st_javascript("return window.innerWidth;")
+        if width is None:
+            params = st.experimental_get_query_params()
+            try:
+                width = int(params.get("width", [1000])[0])
+            except (ValueError, TypeError):
+                width = 1000
+        st.session_state.screen_width = width
 
     st.title("🏢 営業特化SaaS")
     st.markdown("---")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ tenacity>=8.2
 pytest>=8.2
 pytest-mock>=3.14
 streamlit-sortables>=0.2.0
+streamlit-javascript>=0.1.4
 PyYAML>=6.0
 
 jsonschema>=4.0


### PR DESCRIPTION
## Summary
- replace hidden input and inline JS with `streamlit_javascript` component
- fall back to query parameter or default width when JS disabled
- add `streamlit-javascript` dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b153397d648333b9d0040a8829e476