### PR TITLE
Add basic i18n with language switch

### DIFF
--- a/app/pages/history.py
+++ b/app/pages/history.py
@@ -6,11 +6,12 @@ from urllib.parse import urlparse
 from services.storage_service import get_storage_provider
 from core.models import SalesType
 from streamlit_sortables import sort_items
+from translations import t
 
 
 def show_history_page() -> None:
-    st.header("履歴（セッション一覧）")
-    st.write("保存された生成結果を参照・再利用できます。")
+    st.header(t("history_header"))
+    st.write(t("history_desc"))
 
     
     provider = get_storage_provider()

--- a/app/pages/icebreaker.py
+++ b/app/pages/icebreaker.py
@@ -5,10 +5,11 @@ from datetime import datetime
 from core.models import SalesType
 from services.icebreaker import IcebreakerService
 from components.copy_button import copy_button
+from translations import t
 
 def show_icebreaker_page():
-    st.header("🎯 アイスブレイク生成")
-    st.write("営業タイプと業界に応じた、自然で親しみやすいアイスブレイクを生成します。")
+    st.header(t("icebreaker_header"))
+    st.write(t("icebreaker_desc"))
     
     # 履歴からの即時再生成（オートラン）の処理
     if st.session_state.get("icebreaker_autorun"):

--- a/app/pages/post_review.py
+++ b/app/pages/post_review.py
@@ -11,10 +11,11 @@ from services.storage_service import get_storage_provider
 from datetime import datetime
 from components.sales_type import sales_type_selectbox
 from components.copy_button import copy_button
+from translations import t
 
 def show_post_review_page():
-    st.header("🔍 商談後ふりかえり解析")
-    st.write("商談後の議事録やメモを分析し、次回への改善点とアクションプランを生成します。")
+    st.header(t("post_review_header"))
+    st.write(t("post_review_desc"))
     
     # セッション状態の初期化
     if 'post_review_form_data' not in st.session_state:

--- a/app/pages/pre_advice.py
+++ b/app/pages/pre_advice.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 
 import streamlit as st
+from translations import t
 
 from components.copy_button import copy_button
 from components.sales_type import get_sales_type_emoji
@@ -584,25 +585,25 @@ def render_save_section(sales_input: SalesInput, advice: dict):
 
 def show_pre_advice_page():
     """事前アドバイスページを表示"""
-    st.header("事前アドバイス生成")
-    st.write("商談前の準備をサポートします。営業タイプ、業界、商品情報を入力してください。")
+    st.header(t("pre_advice_header"))
+    st.write(t("pre_advice_desc"))
 
     is_mobile = st.session_state.get("screen_width", 1000) < 700
 
     if st.session_state.get("quickstart_mode"):
         submitted, form_data = render_quickstart_form()
     else:
-        if "pre_advice_form_data" not in st.session_state:
-            st.session_state.pre_advice_form_data = {}
-        if is_mobile:
-            tab_form, tab_ice = st.tabs(["入力フォーム", "アイスブレイク"])
-            with tab_form:
+            if "pre_advice_form_data" not in st.session_state:
+                st.session_state.pre_advice_form_data = {}
+            if is_mobile:
+                tab_form, tab_ice = st.tabs([t("input_form_tab"), t("icebreaker_tab")])
+                with tab_form:
+                    submitted, form_data = render_pre_advice_form()
+                with tab_ice:
+                    render_icebreaker_section()
+            else:
                 submitted, form_data = render_pre_advice_form()
-            with tab_ice:
                 render_icebreaker_section()
-        else:
-            submitted, form_data = render_pre_advice_form()
-            render_icebreaker_section()
 
     autorun = st.session_state.pop("pre_advice_autorun", False)
     if submitted or autorun:

--- a/app/pages/search_enhancement.py
+++ b/app/pages/search_enhancement.py
@@ -9,16 +9,17 @@ from datetime import datetime
 from services.search_enhancer import SearchEnhancerService
 from services.settings_manager import SettingsManager
 from services.storage_service import get_storage_provider
+from translations import t
 
 def main():
     st.set_page_config(
-        page_title="検索機能の高度化",
+        page_title=t("search_enhancement_title"),
         page_icon="🔍",
         layout="wide"
     )
-    
-    st.title("🔍 検索機能の高度化")
-    st.markdown("LLMの知識を活用して検索結果の品質向上とスコアリングアルゴリズムを改善します")
+
+    st.title(t("search_enhancement_title"))
+    st.markdown(t("search_enhancement_desc"))
     
     # サービスの初期化
     try:
@@ -31,7 +32,7 @@ def main():
     
     # サイドバー設定
     with st.sidebar:
-        st.header("検索設定")
+        st.header(t("tab_search"))
         
         # 検索タイプの選択
         search_type = st.selectbox(

--- a/app/pages/settings.py
+++ b/app/pages/settings.py
@@ -3,18 +3,19 @@ import json
 from pathlib import Path
 from services.settings_manager import SettingsManager
 from core.models import LLMMode, SearchProvider
+from translations import t
 
 def show_settings_page():
     """設定ページを表示"""
-    st.title("⚙️ 設定・カスタマイズ")
-    st.markdown("アプリケーションの動作をカスタマイズできます。")
+    st.title(t("settings_page_title"))
+    st.markdown(t("settings_page_desc"))
     
     # 設定マネージャーの初期化
     settings_manager = SettingsManager()
     
     # タブで設定を分類
     tab1, tab2, tab3, tab4, tab5 = st.tabs([
-        "🤖 LLM設定", "🔍 検索設定", "🎨 UI設定", "💾 データ設定", "📁 インポート/エクスポート"
+        t("tab_llm"), t("tab_search"), t("tab_ui"), t("tab_data"), t("tab_import_export")
     ])
     
     with tab1:
@@ -34,7 +35,7 @@ def show_settings_page():
 
 def show_llm_settings(settings_manager: SettingsManager):
     """LLM設定を表示"""
-    st.header("LLM設定")
+    st.header(t("tab_llm"))
     
     settings = settings_manager.load_settings()
     
@@ -91,7 +92,7 @@ def show_llm_settings(settings_manager: SettingsManager):
 
 def show_search_settings(settings_manager: SettingsManager):
     """検索設定を表示"""
-    st.header("検索設定")
+    st.header(t("tab_search"))
     
     settings = settings_manager.load_settings()
     
@@ -177,20 +178,23 @@ def show_search_settings(settings_manager: SettingsManager):
 
 def show_ui_settings(settings_manager: SettingsManager):
     """UI設定を表示"""
-    st.header("UI設定")
+    st.header(t("tab_ui"))
     
     settings = settings_manager.load_settings()
     
     col1, col2 = st.columns(2)
-    
+
     with col1:
         # 言語設定
         language = st.selectbox(
-            "言語設定",
+            t("language_setting"),
             options=["ja", "en"],
             index=0 if settings.language == "ja" else 1,
-            help="アプリケーションの表示言語"
+            help=t("language_setting_help"),
+            key="language_select",
         )
+        if st.session_state.get("language") != language:
+            st.session_state["language"] = language
         
         # テーマ設定
         theme = st.selectbox(
@@ -285,7 +289,7 @@ def show_ui_settings(settings_manager: SettingsManager):
 
 def show_data_settings(settings_manager: SettingsManager):
     """データ設定を表示"""
-    st.header("データ設定")
+    st.header(t("tab_data"))
     
     settings = settings_manager.load_settings()
     
@@ -359,7 +363,7 @@ def show_data_settings(settings_manager: SettingsManager):
 
 def show_import_export(settings_manager: SettingsManager):
     """インポート/エクスポート設定を表示"""
-    st.header("設定のインポート/エクスポート")
+    st.header(t("tab_import_export"))
     
     col1, col2 = st.columns(2)
     

--- a/app/translations.py
+++ b/app/translations.py
@@ -1,0 +1,99 @@
+import streamlit as st
+from services.settings_manager import SettingsManager
+
+TRANSLATIONS = {
+    "ja": {
+        "app_title": "🏢 営業特化SaaS",
+        "menu": "メニュー",
+        "select_page": "ページを選択",
+        "pre_advice": "事前アドバイス生成",
+        "post_review": "商談後ふりかえり解析",
+        "icebreaker": "アイスブレイク生成",
+        "history": "履歴",
+        "settings": "設定・カスタマイズ",
+        "search_enhancement": "検索機能の高度化",
+        "quickstart_mode": "クイックスタートモード",
+        "quickstart_help": "必要最小限の入力項目のみ表示",
+
+        "pre_advice_header": "事前アドバイス生成",
+        "pre_advice_desc": "商談前の準備をサポートします。営業タイプ、業界、商品情報を入力してください。",
+        "input_form_tab": "入力フォーム",
+        "icebreaker_tab": "アイスブレイク",
+
+        "post_review_header": "🔍 商談後ふりかえり解析",
+        "post_review_desc": "商談後の議事録やメモを分析し、次回への改善点とアクションプランを生成します。",
+
+        "icebreaker_header": "🎯 アイスブレイク生成",
+        "icebreaker_desc": "営業タイプと業界に応じた、自然で親しみやすいアイスブレイクを生成します。",
+
+        "history_header": "履歴（セッション一覧）",
+        "history_desc": "保存された生成結果を参照・再利用できます。",
+
+        "search_enhancement_title": "🔍 検索機能の高度化",
+        "search_enhancement_desc": "LLMの知識を活用して検索結果の品質向上とスコアリングアルゴリズムを改善します",
+
+        "settings_page_title": "⚙️ 設定・カスタマイズ",
+        "settings_page_desc": "アプリケーションの動作をカスタマイズできます。",
+        "tab_llm": "🤖 LLM設定",
+        "tab_search": "🔍 検索設定",
+        "tab_ui": "🎨 UI設定",
+        "tab_data": "💾 データ設定",
+        "tab_import_export": "📁 インポート/エクスポート",
+        "language_setting": "言語設定",
+        "language_setting_help": "アプリケーションの表示言語",
+    },
+    "en": {
+        "app_title": "🏢 Sales SaaS",
+        "menu": "Menu",
+        "select_page": "Select Page",
+        "pre_advice": "Pre-Advice",
+        "post_review": "Post Review",
+        "icebreaker": "Icebreaker",
+        "history": "History",
+        "settings": "Settings & Customization",
+        "search_enhancement": "Advanced Search",
+        "quickstart_mode": "Quick Start Mode",
+        "quickstart_help": "Display only essential inputs",
+
+        "pre_advice_header": "Pre-Advice",
+        "pre_advice_desc": "Support your preparation before meetings. Provide sales type, industry and product info.",
+        "input_form_tab": "Input Form",
+        "icebreaker_tab": "Icebreaker",
+
+        "post_review_header": "🔍 Post Review Analysis",
+        "post_review_desc": "Analyze meeting notes to generate improvements and next actions.",
+
+        "icebreaker_header": "🎯 Icebreaker Generator",
+        "icebreaker_desc": "Generate natural icebreakers based on sales type and industry.",
+
+        "history_header": "History (Sessions)",
+        "history_desc": "Browse and reuse saved outputs.",
+
+        "search_enhancement_title": "🔍 Search Enhancement",
+        "search_enhancement_desc": "Leverage LLM knowledge to improve search quality and scoring.",
+
+        "settings_page_title": "⚙️ Settings & Customization",
+        "settings_page_desc": "Customize how the application works.",
+        "tab_llm": "🤖 LLM Settings",
+        "tab_search": "🔍 Search Settings",
+        "tab_ui": "🎨 UI Settings",
+        "tab_data": "💾 Data Settings",
+        "tab_import_export": "📁 Import/Export",
+        "language_setting": "Language",
+        "language_setting_help": "Display language of the application",
+    },
+}
+
+
+def get_language() -> str:
+    if "language" in st.session_state:
+        return st.session_state["language"]
+    manager = SettingsManager()
+    lang = manager.load_settings().language
+    st.session_state["language"] = lang
+    return lang
+
+
+def t(key: str) -> str:
+    lang = get_language()
+    return TRANSLATIONS.get(lang, TRANSLATIONS["ja"]).get(key, key)

--- a/app/ui.py
+++ b/app/ui.py
@@ -2,6 +2,7 @@ import os
 import streamlit as st
 from dotenv import load_dotenv
 from streamlit_javascript import st_javascript
+from translations import t
 
 # 環境変数を読み込み
 load_dotenv()
@@ -9,7 +10,7 @@ load_dotenv()
 
 def main():
     st.set_page_config(
-        page_title="営業特化SaaS",
+        page_title=t("app_title"),
         page_icon="🏢",
         layout="wide",
     )
@@ -40,7 +41,7 @@ def main():
                 width = 1000
         st.session_state.screen_width = width
 
-    st.title("🏢 営業特化SaaS")
+    st.title(t("app_title"))
     st.markdown("---")
 
     is_mobile = st.session_state.get("screen_width", 1000) < 700
@@ -52,20 +53,20 @@ def main():
     if is_mobile:
         # サイドバーの代わりにタブでページ切り替え
         st.checkbox(
-            "クイックスタートモード",
-            help="必要最小限の入力項目のみ表示",
+            t("quickstart_mode"),
+            help=t("quickstart_help"),
             key="quickstart_mode",
         )
-        tabs = st.tabs(
-            [
-                "事前アドバイス生成",
-                "商談後ふりかえり解析",
-                "アイスブレイク生成",
-                "履歴",
-                "設定・カスタマイズ",
-                "検索機能の高度化",
-            ]
-        )
+        page_keys = [
+            "pre_advice",
+            "post_review",
+            "icebreaker",
+            "history",
+            "settings",
+            "search_enhancement",
+        ]
+        page_labels = {k: t(k) for k in page_keys}
+        tabs = st.tabs([page_labels[k] for k in page_keys])
         with tabs[0]:
             from pages.pre_advice import show_pre_advice_page
 
@@ -92,50 +93,54 @@ def main():
             show_enhanced_search_page()
     else:
         # デスクトップでは従来どおりサイドバーを使用
-        st.sidebar.title("メニュー")
+        st.sidebar.title(t("menu"))
         if "page_select" not in st.session_state:
-            st.session_state.page_select = "事前アドバイス生成"
+            st.session_state.page_select = "pre_advice"
+
+        page_keys = [
+            "pre_advice",
+            "post_review",
+            "icebreaker",
+            "history",
+            "settings",
+            "search_enhancement",
+        ]
+        page_labels = {k: t(k) for k in page_keys}
 
         page = st.sidebar.selectbox(
-            "ページを選択",
-            [
-                "事前アドバイス生成",
-                "商談後ふりかえり解析",
-                "アイスブレイク生成",
-                "履歴",
-                "設定・カスタマイズ",
-                "検索機能の高度化",
-            ],
+            t("select_page"),
+            options=page_keys,
+            format_func=lambda x: page_labels[x],
             key="page_select",
         )
 
         st.sidebar.checkbox(
-            "クイックスタートモード",
-            help="必要最小限の入力項目のみ表示",
+            t("quickstart_mode"),
+            help=t("quickstart_help"),
             key="quickstart_mode",
         )
 
-        if page == "事前アドバイス生成":
+        if page == "pre_advice":
             from pages.pre_advice import show_pre_advice_page
 
             show_pre_advice_page()
-        elif page == "商談後ふりかえり解析":
+        elif page == "post_review":
             from pages.post_review import show_post_review_page
 
             show_post_review_page()
-        elif page == "アイスブレイク生成":
+        elif page == "icebreaker":
             from pages.icebreaker import show_icebreaker_page
 
             show_icebreaker_page()
-        elif page == "設定・カスタマイズ":
+        elif page == "settings":
             from pages.settings import show_settings_page
 
             show_settings_page()
-        elif page == "履歴":
+        elif page == "history":
             from pages.history import show_history_page
 
             show_history_page()
-        elif page == "検索機能の高度化":
+        elif page == "search_enhancement":
             from pages.search_enhancement import show_enhanced_search_page
 
             show_enhanced_search_page()


### PR DESCRIPTION
## Summary
- Introduce centralized translation maps keyed by AppSettings.language
- Localize UI and pages and add language selection to settings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b154215bb483338189e4f78517afab