### PR TITLE
Validate GCS env vars for storage provider

### DIFF
--- a/GOOGLE_CLOUD_MIGRATION.md
+++ b/GOOGLE_CLOUD_MIGRATION.md
@@ -157,14 +157,25 @@ gcloud secrets list
 
 ### 5.2 Cloud Runサービスにシークレットを追加
 
+GCSにセッションを保存するため、以下の環境変数を設定します：
+
+- `STORAGE_PROVIDER=gcs`
+- `GCS_BUCKET_NAME`（必須）
+- `GCS_PREFIX`（任意、デフォルトは `sessions`）
+
 ```bash
 # 環境変数としてシークレットを追加
 gcloud run services update sales-saas \
   --region=asia-northeast1 \
   --set-env-vars="OPENAI_API_KEY=projects/sales-saas-[YOUR-UNIQUE-ID]/secrets/openai-api-key/versions/latest" \
   --set-env-vars="APP_ENV=production" \
+  --set-env-vars="STORAGE_PROVIDER=gcs" \
+  --set-env-vars="GCS_BUCKET_NAME=your-bucket-name" \
+  --set-env-vars="GCS_PREFIX=sessions" \
   --set-env-vars="DATA_DIR=/tmp"
 ```
+
+ローカル環境からGCSへアクセスする場合は `GOOGLE_APPLICATION_CREDENTIALS` にサービスアカウントJSONのパスを設定してください。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,15 @@ chmod +x start_local.sh
 APP_ENV=local
 OPENAI_API_KEY=sk-xxxx
 DATA_DIR=./data
+STORAGE_PROVIDER=local  # local|gcs
+GCS_BUCKET_NAME=        # required when STORAGE_PROVIDER=gcs
+GCS_PREFIX=sessions     # optional prefix path
 SEARCH_PROVIDER=none   # none|cse|newsapi 等
 CSE_API_KEY=
 CSE_CX=
 ```
+
+`STORAGE_PROVIDER` を `gcs` に設定する場合は、`GCS_BUCKET_NAME`（必須）と必要に応じて `GCS_PREFIX` を指定してください。ローカルからGCSにアクセスする際は `GOOGLE_APPLICATION_CREDENTIALS` にサービスアカウントJSONのパスを設定します。
 
 ## LLMプロバイダのJSONスキーマ対応
 

--- a/env.example
+++ b/env.example
@@ -3,8 +3,8 @@ OPENAI_API_KEY=sk-xxxx
 OPENAI_MODEL=gpt-4o-mini
 DATA_DIR=./data
 STORAGE_PROVIDER=local  # local|gcs
-GCS_BUCKET_NAME=
-GCS_PREFIX=sessions
+GCS_BUCKET_NAME=          # required when STORAGE_PROVIDER=gcs
+GCS_PREFIX=sessions       # optional prefix path
 SEARCH_PROVIDER=none   # none|cse|newsapi 等
 CSE_API_KEY=
 CSE_CX=

--- a/services/storage_service.py
+++ b/services/storage_service.py
@@ -22,7 +22,11 @@ def get_storage_provider():
         if GCSStorageProvider is None:
             raise RuntimeError("GCSStorageProvider not available")
         bucket = os.getenv("GCS_BUCKET_NAME")
+        if not bucket:
+            raise RuntimeError("GCS_BUCKET_NAME environment variable is required for GCS storage")
         prefix = os.getenv("GCS_PREFIX", "sessions")
+        if not prefix:
+            raise RuntimeError("GCS_PREFIX environment variable is required for GCS storage")
         return GCSStorageProvider(bucket_name=bucket, prefix=prefix)
 
     data_dir = os.getenv("DATA_DIR", "./data")

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -1,0 +1,28 @@
+import pytest
+import pytest
+from services import storage_service
+
+
+class DummyProvider:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+def test_gcs_requires_bucket(monkeypatch):
+    monkeypatch.setenv("STORAGE_PROVIDER", "gcs")
+    monkeypatch.delenv("GCS_BUCKET_NAME", raising=False)
+    monkeypatch.delenv("GCS_PREFIX", raising=False)
+    monkeypatch.setattr(storage_service, "GCSStorageProvider", DummyProvider)
+    with pytest.raises(RuntimeError) as exc:
+        storage_service.get_storage_provider()
+    assert "GCS_BUCKET_NAME" in str(exc.value)
+
+
+def test_gcs_requires_prefix(monkeypatch):
+    monkeypatch.setenv("STORAGE_PROVIDER", "gcs")
+    monkeypatch.setenv("GCS_BUCKET_NAME", "bucket")
+    monkeypatch.setenv("GCS_PREFIX", "")
+    monkeypatch.setattr(storage_service, "GCSStorageProvider", DummyProvider)
+    with pytest.raises(RuntimeError) as exc:
+        storage_service.get_storage_provider()
+    assert "GCS_PREFIX" in str(exc.value)


### PR DESCRIPTION
## Summary
- validate required GCS settings in `get_storage_provider`
- document GCS environment variables in README and migration guide
- add tests for missing GCS environment variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1597506c88333bb5d86fa89232d7d