### PR TITLE
feat: export session history

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -149,3 +149,17 @@
 - Environment: Python 3.12.10, streamlit==1.49.0, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0
 
 
+## 2025-09-05
+### Task
+- ストレージプロバイダにCSV/JSONエクスポート機能を追加し、履歴ページからダウンロード可能にした
+  - refs: [providers/storage_local.py, providers/storage_gcs.py, app/pages/history.py, app/translations.py, tests/test_storage_local.py]
+
+### Reviews
+1. **Python上級エンジニア視点**: exportメソッドを共通インタフェース化し、メタデータも含めた変換で拡張性が確保された。
+2. **UI/UX専門家視点**: 履歴ページにダウンロードボタンを配置し、ワンクリックでデータ取得できるため操作性が向上した。
+3. **クラウドエンジニア視点**: GCSプロバイダにも同機能を実装し、ローカルとクラウドで一貫したデータエクスポートが可能になった。
+4. **ユーザー視点**: セッション結果を外部で再利用できるようになり、分析や共有がしやすくなった。
+
+### Testing
+- `pytest -q`
+- Environment: Python 3.12.10, streamlit==1.49.0, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0

--- a/app/pages/history.py
+++ b/app/pages/history.py
@@ -13,9 +13,29 @@ def show_history_page() -> None:
     st.header(t("history_header"))
     st.write(t("history_desc"))
 
-    
+
     provider = get_storage_provider()
     all_sessions: List[Dict[str, Any]] = provider.list_sessions()
+
+    col_exp1, col_exp2 = st.columns(2)
+    with col_exp1:
+        json_data = provider.export_sessions("json", all_sessions)
+        st.download_button(
+            t("history_export_json"),
+            data=json_data,
+            file_name="sessions.json",
+            mime="application/json",
+            key="history_dl_json",
+        )
+    with col_exp2:
+        csv_data = provider.export_sessions("csv", all_sessions)
+        st.download_button(
+            t("history_export_csv"),
+            data=csv_data,
+            file_name="sessions.csv",
+            mime="text/csv",
+            key="history_dl_csv",
+        )
 
     # フィルタUI
     with st.expander("フィルタ", expanded=True):

--- a/app/translations.py
+++ b/app/translations.py
@@ -28,6 +28,8 @@ TRANSLATIONS = {
 
         "history_header": "履歴（セッション一覧）",
         "history_desc": "保存された生成結果を参照・再利用できます。",
+        "history_export_json": "JSONでダウンロード",
+        "history_export_csv": "CSVでダウンロード",
 
         "search_enhancement_title": "🔍 検索機能の高度化",
         "search_enhancement_desc": "LLMの知識を活用して検索結果の品質向上とスコアリングアルゴリズムを改善します",
@@ -68,6 +70,8 @@ TRANSLATIONS = {
 
         "history_header": "History (Sessions)",
         "history_desc": "Browse and reuse saved outputs.",
+        "history_export_json": "Download JSON",
+        "history_export_csv": "Download CSV",
 
         "search_enhancement_title": "🔍 Search Enhancement",
         "search_enhancement_desc": "Leverage LLM knowledge to improve search quality and scoring.",

--- a/tests/test_storage_local.py
+++ b/tests/test_storage_local.py
@@ -1,3 +1,4 @@
+import csv
 import json
 from pathlib import Path
 from typing import Any, Dict
@@ -74,5 +75,22 @@ def test_delete_session(tmp_path: Path):
 
     with pytest.raises(FileNotFoundError):
         provider.load_session(session_id)
+
+
+def test_export_sessions(tmp_path: Path):
+    provider = LocalStorageProvider(data_dir=str(tmp_path))
+    provider.save_session({"type": "pre_advice", "input": {}, "output": {}}, user_id="u1", success=True)
+    provider.save_session({"type": "post_review", "input": {}, "output": {}}, user_id="u2", success=False)
+
+    json_data = provider.export_sessions("json")
+    parsed = json.loads(json_data)
+    assert len(parsed) == 2
+    assert {"session_id", "user_id", "success"}.issubset(parsed[0].keys())
+
+    csv_data = provider.export_sessions("csv")
+    reader = csv.DictReader(csv_data.splitlines())
+    rows = list(reader)
+    assert len(rows) == 2
+    assert {"session_id", "user_id", "success"}.issubset(rows[0].keys())
 
 


### PR DESCRIPTION
## Summary
- support JSON/CSV export in local & GCS storage providers
- allow history page to download session data with metadata
- add tests for export functionality

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1637d7fd48333b5fe021b7e76c196