### PR TITLE
feat: add PII masking and log sanitization

### DIFF
--- a/services/logger.py
+++ b/services/logger.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from typing import Optional
 from pathlib import Path
 
+from .utils import mask_pii
+
 class Logger:
     """アプリケーション全体のログ管理サービス"""
     
@@ -59,29 +61,29 @@ class Logger:
     
     def info(self, message: str):
         """情報ログ"""
-        self.logger.info(message)
-    
+        self.logger.info(mask_pii(message))
+
     def warning(self, message: str):
         """警告ログ"""
-        self.logger.warning(message)
-    
+        self.logger.warning(mask_pii(message))
+
     def error(self, message: str, exc_info: Optional[Exception] = None):
         """エラーログ"""
         if exc_info:
-            self.logger.error(message, exc_info=exc_info)
+            self.logger.error(mask_pii(message), exc_info=exc_info)
         else:
-            self.logger.error(message)
-    
+            self.logger.error(mask_pii(message))
+
     def debug(self, message: str):
         """デバッグログ"""
-        self.logger.debug(message)
-    
+        self.logger.debug(mask_pii(message))
+
     def critical(self, message: str, exc_info: Optional[Exception] = None):
         """重大エラーログ"""
         if exc_info:
-            self.logger.critical(message, exc_info=exc_info)
+            self.logger.critical(mask_pii(message), exc_info=exc_info)
         else:
-            self.logger.critical(message)
+            self.logger.critical(mask_pii(message))
     
     def log_user_action(self, user_action: str, details: dict = None):
         """ユーザーアクションのログ"""

--- a/services/utils.py
+++ b/services/utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+
 
 def escape_braces(text: str) -> str:
     """Escape curly braces in the given text for safe formatting.
@@ -11,3 +13,24 @@ def escape_braces(text: str) -> str:
     if not isinstance(text, str):
         return text
     return text.replace("{", "{{").replace("}", "}}")
+
+
+EMAIL_REGEX = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+PHONE_REGEX = re.compile(r"\+?\d[\d\-\s]{9,}\d")
+NAME_REGEX = re.compile(r"\b[A-Z][a-z]+\s+[A-Z][a-z]+\b|[\u4e00-\u9fff]{3,}")
+
+
+def mask_pii(text: str) -> str:
+    """Mask common personally identifiable information in the given text.
+
+    This function replaces email addresses, phone numbers, and personal names
+    with asterisks (``***``) to prevent accidental logging of sensitive data.
+    """
+
+    if not isinstance(text, str):
+        text = str(text)
+
+    text = EMAIL_REGEX.sub("***", text)
+    text = PHONE_REGEX.sub("***", text)
+    text = NAME_REGEX.sub("***", text)
+    return text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,14 @@
-from services.utils import escape_braces
+from services.utils import escape_braces, mask_pii
 
 
 def test_escape_braces():
     assert escape_braces('abc') == 'abc'
     assert escape_braces('{a}') == '{{a}}'
     assert escape_braces('a{b}c') == 'a{{b}}c'
+
+
+def test_mask_pii():
+    assert mask_pii('Contact user@example.com') == 'Contact ***'
+    assert mask_pii('Call me at 090-1234-5678') == 'Call me at ***'
+    assert mask_pii('John Doe logged in') == '*** logged in'
+    assert mask_pii('山田太郎が参加') == '***が参加'


### PR DESCRIPTION
## Summary
- add `mask_pii` utility to anonymize emails, phone numbers and names
- sanitize logger output by masking PII before writing
- cover typical patterns with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b184628be48333aa15d063e3000476