### PR TITLE
refactor: extract page labels to translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ pytest tests/test_icebreaker.py -q
 pytest tests/test_storage_local.py -q
 ```
 
+## 翻訳キーの命名規則
+
+- 重複を避けるため、翻訳キーは `page_element_name` 形式で命名する
+  - 例: `pre_advice_industry_label`, `post_review_product_label`
+
 ## プロジェクト構造
 
 ```

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -178,3 +178,19 @@
 ### Testing
 - `pytest -q`
 - Environment: Python 3.12.10, streamlit==1.49.0, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0
+
+## 2025-08-29
+### Task
+- フィールドラベルのハードコードを翻訳キーに置き換え、辞書とREADMEに命名規則を追加
+  - refs: [app/pages/pre_advice.py, app/pages/post_review.py, app/translations.py, README.md]
+
+### Reviews
+1. **Python上級エンジニア視点**: テキスト定数を一元管理することで保守性と再利用性が向上した。
+2. **UI/UX専門家視点**: ラベルが翻訳可能になり、将来的な多言語展開への準備が整った。
+3. **クラウドエンジニア視点**: キー命名規則の明文化で衝突を防ぎ、環境ごとの整合性が保たれる。
+4. **ユーザー視点**: 選択した言語でUIが統一され、利用体験が向上した。
+
+### Testing
+- `pytest -q`
+- Environment: Python 3.12.10, streamlit==1.49.0, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0
+

--- a/app/pages/post_review.py
+++ b/app/pages/post_review.py
@@ -29,14 +29,14 @@ def show_post_review_page():
             sales_type = sales_type_selectbox(key="post_review_sales_type")
             
             industry = st.text_input(
-                "業界 *", 
+                t("post_review_industry_label"),
                 placeholder="例: IT、製造業、金融業",
                 help="対象となる業界を入力してください",
                 key="post_review_industry"
             )
             
             product = st.text_input(
-                "商品・サービス *", 
+                t("post_review_product_label"),
                 placeholder="例: SaaS、コンサルティング",
                 help="提供する商品・サービスを入力してください",
                 key="post_review_product"

--- a/app/pages/pre_advice.py
+++ b/app/pages/pre_advice.py
@@ -54,7 +54,7 @@ def render_pre_advice_form():
             )
 
             industry = st.text_input(
-                "業界 *",
+                t("pre_advice_industry_label"),
                 placeholder="例: IT、製造業、金融業",
                 help="対象となる業界を入力してください（2文字以上）",
                 key="industry_input",
@@ -70,9 +70,13 @@ def render_pre_advice_form():
                 else:
                     st.success("✅ 業界名が有効です")
 
-            product_label = "商品・サービス *" if not quickstart else "商品・サービス"
+            product_label_key = (
+                "pre_advice_product_label"
+                if not quickstart
+                else "pre_advice_product_label_optional"
+            )
             product = st.text_input(
-                product_label,
+                t(product_label_key),
                 placeholder="例: SaaS、コンサルティング",
                 help="提供する商品・サービスを入力してください（2文字以上）",
                 key="product_input",
@@ -721,7 +725,7 @@ def _legacy_show_pre_advice_page():
             )
             
             industry = st.text_input(
-                "業界 *", 
+                t("pre_advice_industry_label"),
                 placeholder="例: IT、製造業、金融業",
                 help="対象となる業界を入力してください（2文字以上）",
                 key="industry_input"
@@ -737,7 +741,7 @@ def _legacy_show_pre_advice_page():
                     st.success("✅ 業界名が有効です")
             
             product = st.text_input(
-                "商品・サービス *", 
+                t("pre_advice_product_label"),
                 placeholder="例: SaaS、コンサルティング",
                 help="提供する商品・サービスを入力してください（2文字以上）",
                 key="product_input"

--- a/app/translations.py
+++ b/app/translations.py
@@ -45,6 +45,11 @@ TRANSLATIONS = {
         "tab_import_export": "📁 インポート/エクスポート",
         "language_setting": "言語設定",
         "language_setting_help": "アプリケーションの表示言語",
+        "pre_advice_industry_label": "業界 *",
+        "pre_advice_product_label": "商品・サービス *",
+        "pre_advice_product_label_optional": "商品・サービス",
+        "post_review_industry_label": "業界 *",
+        "post_review_product_label": "商品・サービス *",
     },
     "en": {
         "app_title": "🏢 Sales SaaS",
@@ -89,6 +94,11 @@ TRANSLATIONS = {
         "tab_import_export": "📁 Import/Export",
         "language_setting": "Language",
         "language_setting_help": "Display language of the application",
+        "pre_advice_industry_label": "Industry *",
+        "pre_advice_product_label": "Product/Service *",
+        "pre_advice_product_label_optional": "Product/Service",
+        "post_review_industry_label": "Industry *",
+        "post_review_product_label": "Product/Service *",
     },
 }
 


### PR DESCRIPTION
## Summary
- replace hard-coded industry and product labels in pre_advice/post_review pages with `translations.t`
- add corresponding ja/en keys and document `page_element_name` translation key naming rule
- log work in WORKLOG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b193d0a4a88333ada4cb1a85d9045d