### PR TITLE
feat: add mobile hamburger menu

### DIFF
--- a/app/translations.py
+++ b/app/translations.py
@@ -14,6 +14,8 @@ TRANSLATIONS = {
         "search_enhancement": "検索機能の高度化",
         "quickstart_mode": "クイックスタートモード",
         "quickstart_help": "必要最小限の入力項目のみ表示",
+        "sidebar_toggle_help": "サイドバーを表示/非表示",
+        "tab_navigation_hint": "ページ切替は下のタブから行えます",
         "fill_later": "後で入力する",
         "later_help": "必須項目以外は後から編集できます",
 
@@ -63,6 +65,8 @@ TRANSLATIONS = {
         "search_enhancement": "Advanced Search",
         "quickstart_mode": "Quick Start Mode",
         "quickstart_help": "Display only essential inputs",
+        "sidebar_toggle_help": "Show or hide sidebar",
+        "tab_navigation_hint": "Use the tabs below to switch pages",
         "fill_later": "Fill later",
         "later_help": "Optional fields can be edited later",
 

--- a/app/ui.py
+++ b/app/ui.py
@@ -46,17 +46,33 @@ def main():
 
     is_mobile = st.session_state.get("screen_width", 1000) < 700
 
+    # セッションステート初期化
+    st.session_state.setdefault("show_sidebar", False)
+    st.session_state.setdefault("quickstart_mode", False)
+
     # 環境変数の確認
     if not os.getenv("OPENAI_API_KEY"):
         st.warning("⚠️ OPENAI_API_KEYが設定されていません。一部機能が制限されます。")
 
     if is_mobile:
-        # サイドバーの代わりにタブでページ切り替え
-        st.checkbox(
-            t("quickstart_mode"),
-            help=t("quickstart_help"),
-            key="quickstart_mode",
-        )
+        # ハンバーガーメニューでサイドバーをトグル表示
+        cols = st.columns([1, 9])
+        with cols[0]:
+            if st.button("☰", help=t("sidebar_toggle_help"), key="menu_toggle"):
+                st.session_state.show_sidebar = not st.session_state.show_sidebar
+            # aria-label: toggle navigation menu
+
+        if st.session_state.show_sidebar:
+            with st.expander(t("menu"), expanded=True):
+                # aria-label: mobile sidebar content
+                st.checkbox(
+                    t("quickstart_mode"),
+                    help=t("quickstart_help"),
+                    key="quickstart_mode",
+                )  # aria-label: toggle quickstart mode
+
+        st.caption(t("tab_navigation_hint"))
+
         page_keys = [
             "pre_advice",
             "post_review",
@@ -66,6 +82,7 @@ def main():
             "search_enhancement",
         ]
         page_labels = {k: t(k) for k in page_keys}
+        # aria-label: page navigation tabs
         tabs = st.tabs([page_labels[k] for k in page_keys])
         with tabs[0]:
             from pages.pre_advice import show_pre_advice_page


### PR DESCRIPTION
## Summary
- add hamburger menu to mobile layout and toggleable sidebar expander
- provide translated tooltips and tab navigation hints
- annotate UI elements with accessibility comments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1974bc4648333aac262e6be552999