### PR TITLE
feat: allow noninteractive GCP migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,16 @@ CSE_CX=
 
 `STORAGE_PROVIDER` を `gcs` に設定する場合は、`GCS_BUCKET_NAME`（必須）と必要に応じて `GCS_PREFIX` を指定してください。ローカルからGCSにアクセスする際は `GOOGLE_APPLICATION_CREDENTIALS` にサービスアカウントJSONのパスを設定します。
 
+## GCPへの移行
+
+`migrate-to-gcp.sh` を使うとアプリを Google Cloud にデプロイできます。非対話モードでの実行例:
+
+```bash
+./migrate-to-gcp.sh -p my-proj -r asia-northeast1
+```
+
+`OPENAI_API_KEY` は環境変数から取得され、未設定の場合のみ実行時にプロンプトが表示されます。
+
 ## LLMプロバイダのJSONスキーマ対応
 
 `OpenAIProvider.call_llm` に `json_schema` を渡すと、OpenAI API は

--- a/migrate-to-gcp.sh
+++ b/migrate-to-gcp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # 🚀 Google Cloud移行スクリプト（営業特化SaaS用）
-# 使用方法: ./migrate-to-gcp.sh
+# 使用方法: ./migrate-to-gcp.sh [-p PROJECT_ID] [-r REGION] [-s SERVICE_NAME] [-n REPOSITORY_NAME]
 
 set -e
 
@@ -9,6 +9,20 @@ PROJECT_ID="sales-saas-[YOUR-UNIQUE-ID]"
 REGION="asia-northeast1"
 SERVICE_NAME="sales-saas"
 REPOSITORY_NAME="sales-saas-repo"
+
+# 引数の取得
+while getopts ":p:r:s:n:" opt; do
+    case "$opt" in
+        p) PROJECT_ID="$OPTARG" ;;
+        r) REGION="$OPTARG" ;;
+        s) SERVICE_NAME="$OPTARG" ;;
+        n) REPOSITORY_NAME="$OPTARG" ;;
+        *)
+            echo "Usage: $0 [-p PROJECT_ID] [-r REGION] [-s SERVICE_NAME] [-n REPOSITORY_NAME]" >&2
+            exit 1
+            ;;
+    esac
+done
 
 # 色付きのログ出力
 log_info() {
@@ -157,8 +171,11 @@ deploy_to_cloud_run() {
 setup_secrets() {
     log_info "シークレットの設定中..."
 
-    # OpenAI APIキーの入力
-    read -p "OpenAI APIキーを入力してください: " OPENAI_API_KEY
+    # OpenAI APIキーの取得（環境変数がなければプロンプト）
+    OPENAI_API_KEY="${OPENAI_API_KEY:-}"
+    if [[ -z "$OPENAI_API_KEY" ]]; then
+        read -p "OpenAI APIキーを入力してください: " OPENAI_API_KEY
+    fi
 
     if [[ -n "$OPENAI_API_KEY" ]]; then
         # シークレットの作成または新バージョンの追加


### PR DESCRIPTION
## Summary
- support command-line options for project settings in migrate-to-gcp.sh
- read OpenAI API key from environment and prompt only if unset
- document non-interactive usage example

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b19ca515748333b731cce945c22f59