### PR TITLE
feat: split pre-advice form into steps

### DIFF
--- a/app/pages/pre_advice.py
+++ b/app/pages/pre_advice.py
@@ -24,7 +24,8 @@ def update_form_data(src_key: str, dest_key: str) -> None:
 
 def render_form():
     """事前アドバイス入力フォームを段階的に表示"""
-    total_steps = 3
+    step_titles = ["基本情報", "詳細", "制約"]
+    total_steps = len(step_titles)
     if "pre_form_step" not in st.session_state:
         st.session_state.pre_form_step = 1
     if "pre_advice_form_data" not in st.session_state:
@@ -32,7 +33,7 @@ def render_form():
 
     step = st.session_state.pre_form_step
     st.progress(step / total_steps)
-    st.markdown(f"### ステップ {step}/{total_steps}")
+    st.markdown(f"### {step_titles[step - 1]} ({step}/{total_steps})")
 
     quickstart = st.session_state.get("quickstart_mode", False)
     submitted = False

--- a/tests/test_pre_advice.py
+++ b/tests/test_pre_advice.py
@@ -25,6 +25,41 @@ def test_step_progression(monkeypatch):
     assert st.session_state.pre_form_step == 2
 
 
+def test_step_titles_and_progress(monkeypatch):
+    st.session_state.clear()
+    st.session_state.pre_form_step = 1
+    monkeypatch.setattr(st, "rerun", lambda: None)
+
+    progress_calls = []
+    markdown_calls = []
+
+    monkeypatch.setattr(st, "progress", lambda v: progress_calls.append(v))
+    monkeypatch.setattr(st, "markdown", lambda text, **kwargs: markdown_calls.append(text))
+
+    responses = iter([True, False, True, False, False])
+
+    def fake_submit(label, **kwargs):
+        return next(responses)
+
+    monkeypatch.setattr(st, "form_submit_button", fake_submit)
+
+    render_form()
+    assert progress_calls[-1] == 1 / 3
+    assert any("基本情報" in m for m in markdown_calls)
+
+    progress_calls.clear()
+    markdown_calls.clear()
+    render_form()
+    assert progress_calls[-1] == 2 / 3
+    assert any("詳細" in m for m in markdown_calls)
+
+    progress_calls.clear()
+    markdown_calls.clear()
+    render_form()
+    assert progress_calls[-1] == 1
+    assert any("制約" in m for m in markdown_calls)
+
+
 def test_final_submission(monkeypatch):
     st.session_state.clear()
     st.session_state.pre_form_step = 3


### PR DESCRIPTION
## Summary
- split pre-advice form into basic info, details, and constraints steps
- show progress bar and titles for each step
- add regression test for form navigation and progress

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1ac3ec9e4833388b11ddad60cb62a