### PR TITLE
feat: parameterize port for Cloud Run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1
+    PIP_NO_CACHE_DIR=1 \
+    PORT=8080
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt
@@ -21,7 +22,7 @@ COPY . .
 RUN chown -R sales:sales /app
 USER sales
 
-EXPOSE 8080
-HEALTHCHECK CMD curl -fsS http://localhost:8080/_stcore/health || exit 1
-ENTRYPOINT ["streamlit", "run", "app/ui.py", "--server.port=8080", "--server.address=0.0.0.0"]
+EXPOSE ${PORT}
+HEALTHCHECK CMD curl -fsS http://localhost:${PORT}/_stcore/health || exit 1
+ENTRYPOINT ["sh", "-c", "streamlit run app/ui.py --server.port=${PORT} --server.address=0.0.0.0"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,16 @@ services:
   web:
     build: .
     ports:
-      - "8080:8080"
+      - "${PORT:-8080}:${PORT:-8080}"
     env_file:
       - .env
+    environment:
+      - PORT=${PORT:-8080}
     volumes:
       - ./:/app
       - ./data:/app/data
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:8080/_stcore/health || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:${PORT:-8080}/_stcore/health || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/start_docker.sh
+++ b/start_docker.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -e
+
+export PORT=${PORT:-8080}
 cp -n env.example .env || true
 docker compose up --build
 


### PR DESCRIPTION
## Summary
- introduce PORT env in Dockerfile and use it for expose, healthcheck and entrypoint
- pass PORT into docker-compose and start_docker.sh for local runs

## Testing
- `pytest`
- `docker build -t sales-saas:test .` *(fails: docker command not found)*
- `gcloud --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ad6db9708333a5a114fa00560f45