### PR TITLE
feat: add Firestore storage provider

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -294,3 +294,19 @@
 - `pytest -q` で 101 件のテストが成功
 - Environment: Python 3.12.10, streamlit==1.49.0, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0
 
+
+## 2025-09-12
+### Task
+- Firestore 向けストレージプロバイダを追加し、`tenants/{tenant_id}/sessions/{session_id}` パスでデータを保存・取得できるよう実装
+  - refs: [providers/storage_firestore.py, services/storage_service.py, tests/test_storage_service.py, requirements.txt, env.example]
+
+### Reviews
+1. **Python上級エンジニア視点**: Firestore クライアントの接続とテナント別コレクション構造が明確で、マルチテナント拡張が容易。
+2. **UI/UX専門家視点**: ストレージ層のDIが拡張され、環境に応じた保存先の切替がシンプルになり利用者への提供が柔軟に。
+3. **クラウドエンジニア視点**: `GOOGLE_APPLICATION_CREDENTIALS` と `FIRESTORE_TENANT_ID` を必須化することで、認証とデータ分離が堅牢に。
+4. **ユーザー視点**: セッション履歴がクラウドに安全に保存され、異なる端末からもアクセスしやすくなる。
+
+### Testing
+- `pytest -q`
+- Environment: Python 3.12.10, streamlit==1.49.0, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0, google-cloud-firestore==2.21.0
+

--- a/env.example
+++ b/env.example
@@ -2,9 +2,11 @@ APP_ENV=local
 OPENAI_API_KEY=sk-xxxx
 OPENAI_MODEL=gpt-4o-mini
 DATA_DIR=./data
-STORAGE_PROVIDER=local  # local|gcs
+STORAGE_PROVIDER=local  # local|gcs|firestore
 GCS_BUCKET_NAME=          # required when STORAGE_PROVIDER=gcs
 GCS_PREFIX=sessions       # optional prefix path
+FIRESTORE_TENANT_ID=      # required when STORAGE_PROVIDER=firestore
+# GOOGLE_APPLICATION_CREDENTIALS=path/to/cred.json  # required when STORAGE_PROVIDER=firestore
 SEARCH_PROVIDER=none   # none|cse|newsapi 等
 CSE_API_KEY=
 CSE_CX=

--- a/providers/storage_firestore.py
+++ b/providers/storage_firestore.py
@@ -1,0 +1,172 @@
+import csv
+import io
+import json
+import os
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List
+
+from google.cloud import firestore
+
+
+class FirestoreStorageProvider:
+    """Firestore based session storage provider."""
+
+    def __init__(self, tenant_id: str, credentials_path: str | None = None) -> None:
+        if not tenant_id:
+            raise ValueError("tenant_id is required")
+        if credentials_path:
+            if not os.path.exists(credentials_path):
+                raise RuntimeError("GOOGLE_APPLICATION_CREDENTIALS file not found")
+            self.client = firestore.Client.from_service_account_json(credentials_path)
+        else:
+            self.client = firestore.Client()
+        self.tenant_id = tenant_id
+
+    def _sessions_collection(self):
+        return (
+            self.client.collection("tenants")
+            .document(self.tenant_id)
+            .collection("sessions")
+        )
+
+    def _doc(self, session_id: str):
+        return self._sessions_collection().document(session_id)
+
+    def save_session(
+        self,
+        data: Dict[str, Any],
+        session_id: str | None = None,
+        user_id: str | None = None,
+        team_id: str | None = None,
+        success: bool | None = None,
+    ) -> str:
+        if session_id is None:
+            session_id = str(uuid.uuid4())
+        if user_id is None:
+            user_id = os.getenv("USER_ID", "anonymous")
+        if team_id is None:
+            team_id = os.getenv("TEAM_ID", "unknown")
+        if success is None:
+            success = data.get("success", True)
+        doc = self._doc(session_id)
+        doc.set(
+            {
+                "session_id": session_id,
+                "user_id": user_id,
+                "team_id": team_id,
+                "created_at": datetime.now().isoformat(),
+                "success": bool(success),
+                "pinned": False,
+                "tags": [],
+                "data": data,
+            }
+        )
+        return session_id
+
+    def load_session(self, session_id: str) -> Dict[str, Any]:
+        doc = self._doc(session_id).get()
+        if not doc.exists:
+            raise FileNotFoundError(f"session {session_id} not found")
+        return doc.to_dict()
+
+    def list_sessions(self) -> List[Dict[str, Any]]:
+        sessions: List[Dict[str, Any]] = []
+        for doc in self._sessions_collection().stream():
+            sessions.append(doc.to_dict())
+        return sorted(
+            sessions,
+            key=lambda x: (x.get("pinned", False), x.get("created_at", "")),
+            reverse=True,
+        )
+
+    def export_sessions(
+        self,
+        fmt: str = "json",
+        sessions: List[Dict[str, Any]] | None = None,
+    ) -> str:
+        if sessions is None:
+            sessions = self.list_sessions()
+        if fmt == "json":
+            return json.dumps(sessions, ensure_ascii=False, indent=2)
+        if fmt == "csv":
+            output = io.StringIO()
+            fieldnames = [
+                "session_id",
+                "user_id",
+                "team_id",
+                "created_at",
+                "success",
+                "pinned",
+                "tags",
+                "type",
+            ]
+            writer = csv.DictWriter(output, fieldnames=fieldnames)
+            writer.writeheader()
+            for s in sessions:
+                writer.writerow(
+                    {
+                        "session_id": s.get("session_id"),
+                        "user_id": s.get("user_id"),
+                        "team_id": s.get("team_id"),
+                        "created_at": s.get("created_at"),
+                        "success": s.get("success"),
+                        "pinned": s.get("pinned"),
+                        "tags": ",".join(s.get("tags", [])),
+                        "type": (s.get("data") or {}).get("type"),
+                    }
+                )
+            return output.getvalue()
+        raise ValueError("Unsupported format")
+
+    def delete_session(self, session_id: str) -> bool:
+        doc_ref = self._doc(session_id)
+        doc = doc_ref.get()
+        if not doc.exists:
+            return False
+        doc_ref.delete()
+        return True
+
+    def set_pinned(self, session_id: str, pinned: bool) -> bool:
+        doc_ref = self._doc(session_id)
+        doc = doc_ref.get()
+        if not doc.exists:
+            return False
+        try:
+            doc_ref.update({"pinned": bool(pinned)})
+            return True
+        except Exception:
+            return False
+
+    def update_tags(self, session_id: str, tags: List[str]) -> bool:
+        doc_ref = self._doc(session_id)
+        doc = doc_ref.get()
+        if not doc.exists:
+            return False
+        try:
+            normalized: List[str] = []
+            seen = set()
+            for t in tags:
+                if not isinstance(t, str):
+                    continue
+                name = t.strip()
+                if not name or name in seen:
+                    continue
+                seen.add(name)
+                normalized.append(name)
+            doc_ref.update({"tags": normalized})
+            return True
+        except Exception:
+            return False
+
+    def save_data(self, filename: str, data: Dict[str, Any]) -> str:
+        if "/" in filename:
+            raise ValueError("Invalid filename")
+        doc_ref = (
+            self.client.collection("tenants")
+            .document(self.tenant_id)
+            .collection("data")
+            .document(filename)
+        )
+        doc_ref.set(data)
+        return filename

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ PyYAML>=6.0
 jsonschema>=4.0
 google-cloud-storage>=2.16
 google-cloud-secret-manager>=2.20
+google-cloud-firestore>=2.16

--- a/services/storage_service.py
+++ b/services/storage_service.py
@@ -7,6 +7,11 @@ try:
 except Exception:  # pragma: no cover
     GCSStorageProvider = None
 
+try:
+    from providers.storage_firestore import FirestoreStorageProvider  # type: ignore
+except Exception:  # pragma: no cover
+    FirestoreStorageProvider = None
+
 
 def get_storage_provider():
     """Return storage provider based on environment"""
@@ -29,6 +34,21 @@ def get_storage_provider():
         if not prefix:
             raise RuntimeError("GCS_PREFIX environment variable is required for GCS storage")
         return GCSStorageProvider(bucket_name=bucket, prefix=prefix)
+
+    if provider == "firestore":
+        if FirestoreStorageProvider is None:
+            raise RuntimeError("FirestoreStorageProvider not available")
+        credentials = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        if not credentials:
+            raise RuntimeError(
+                "GOOGLE_APPLICATION_CREDENTIALS environment variable is required for Firestore storage"
+            )
+        tenant_id = os.getenv("FIRESTORE_TENANT_ID")
+        if not tenant_id:
+            raise RuntimeError(
+                "FIRESTORE_TENANT_ID environment variable is required for Firestore storage"
+            )
+        return FirestoreStorageProvider(tenant_id=tenant_id, credentials_path=credentials)
 
     data_dir = os.getenv("DATA_DIR", "./data")
     return LocalStorageProvider(data_dir=data_dir)

--- a/tests/test_storage_service.py
+++ b/tests/test_storage_service.py
@@ -1,5 +1,4 @@
 import pytest
-import pytest
 from services import storage_service
 
 
@@ -26,3 +25,25 @@ def test_gcs_requires_prefix(monkeypatch):
     with pytest.raises(RuntimeError) as exc:
         storage_service.get_storage_provider()
     assert "GCS_PREFIX" in str(exc.value)
+
+
+def test_firestore_requires_credentials(monkeypatch):
+    monkeypatch.setenv("STORAGE_PROVIDER", "firestore")
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.setenv("FIRESTORE_TENANT_ID", "tenant")
+    monkeypatch.setattr(storage_service, "FirestoreStorageProvider", DummyProvider)
+    with pytest.raises(RuntimeError) as exc:
+        storage_service.get_storage_provider()
+    assert "GOOGLE_APPLICATION_CREDENTIALS" in str(exc.value)
+
+
+def test_firestore_requires_tenant(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "firestore")
+    credentials = tmp_path / "cred.json"
+    credentials.write_text("{}")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(credentials))
+    monkeypatch.delenv("FIRESTORE_TENANT_ID", raising=False)
+    monkeypatch.setattr(storage_service, "FirestoreStorageProvider", DummyProvider)
+    with pytest.raises(RuntimeError) as exc:
+        storage_service.get_storage_provider()
+    assert "FIRESTORE_TENANT_ID" in str(exc.value)


### PR DESCRIPTION
## Summary
- add Firestore storage provider saving sessions under tenants/{tenant_id}/sessions/{session_id}
- allow selecting Firestore via STORAGE_PROVIDER with env-based credentials
- document new FIRESTORE_TENANT_ID and dependency

## Testing
- `make lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24bda89908333ab6d8f0f4bff3ade