### PR TITLE
Add Cloud Run deployment config and make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: run docker-run test lint clean docker-build help
+.PHONY: run docker-run test lint clean docker-build deploy-cloudrun help
 
 # デフォルトターゲット
 all: run
@@ -35,6 +35,10 @@ clean:
 docker-build:
 	docker build -t sales-saas .
 
+# Cloud Run へデプロイ
+deploy-cloudrun:
+	gcloud run services replace cloudrun/cloudrun.yaml --region=asia-northeast1
+
 # ヘルプ
 help:
 	@echo "利用可能なコマンド:"
@@ -44,4 +48,5 @@ help:
 	@echo "  lint        - 構文チェック"
 	@echo "  clean       - クリーンアップ"
 	@echo "  docker-build- Dockerイメージビルド"
+	@echo "  deploy-cloudrun- Cloud Run にデプロイ"
 	@echo "  help        - このヘルプを表示"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ CSE_CX=
 
 `OPENAI_API_KEY` は環境変数から取得され、未設定の場合のみ実行時にプロンプトが表示されます。
 
+## Cloud Run デプロイ
+
+`cloudrun/` ディレクトリに Cloud Run 用の `Dockerfile` と `cloudrun.yaml` を配置しています。
+
+1. イメージをビルドし Artifact Registry へプッシュ:
+
+```bash
+gcloud builds submit --tag asia-northeast1-docker.pkg.dev/$PROJECT_ID/sales-saas-repo/sales-saas
+```
+
+2. Cloud Run サービスを更新:
+
+```bash
+make deploy-cloudrun
+```
+
+`cloudrun/cloudrun.yaml` にはポート `8080` と GCP 用環境変数が定義されています。
+
 ## LLMプロバイダのJSONスキーマ対応
 
 `OpenAIProvider.call_llm` に `json_schema` を渡すと、OpenAI API は
@@ -107,6 +125,7 @@ make run         # ローカル環境で起動
 make docker-run  # Dockerで起動
 make test        # テスト実行
 make lint        # 構文チェック
+make deploy-cloudrun  # Cloud Run にデプロイ
 ```
 
 ## 翻訳キーの命名規則

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -310,3 +310,16 @@
 - `pytest -q`
 - Environment: Python 3.12.10, streamlit==1.49.0, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0, google-cloud-firestore==2.21.0
 
+## 2025-09-13
+### Task
+- Cloud Run 用ディレクトリを追加し、Dockerfile と cloudrun.yaml を配置
+- Cloud Run へのデプロイ手順を README に追記し、Makefile に deploy-cloudrun ターゲットを追加
+### Reviews
+1. **Python上級エンジニア視点**: Cloud Run 用設定がリポジトリに整理され、再利用が容易。
+2. **UI/UX専門家視点**: README に手順が追記され、クラウドデプロイの導線が明確に。
+3. **クラウドエンジニア視点**: cloudrun.yaml に環境変数とポートが定義され、GCP でのデプロイがスムーズ。
+4. **ユーザー視点**: make コマンドでデプロイでき、利用開始までの手順がシンプルに。
+### Testing
+- `pytest -q`
+- `make docker-build` (Docker がインストールされておらず失敗)
+- Environment: Python 3.12.10, streamlit==1.49.1, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0

--- a/cloudrun/Dockerfile
+++ b/cloudrun/Dockerfile
@@ -1,0 +1,47 @@
+FROM python:3.11-slim AS builder
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+COPY requirements.txt .
+RUN python -m venv /opt/venv && \
+    /opt/venv/bin/pip install --upgrade pip && \
+    /opt/venv/bin/pip install -r requirements.txt
+
+
+FROM python:3.11-slim AS runtime
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+# create non-root user
+RUN addgroup --system sales \
+    && adduser --system --ingroup sales sales
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PORT=8080 \
+    PATH="/opt/venv/bin:$PATH"
+
+COPY --from=builder /opt/venv /opt/venv
+
+COPY app app
+COPY core core
+COPY services services
+COPY providers providers
+COPY prompts prompts
+COPY config config
+
+# adjust permissions and switch to non-root user
+RUN chown -R sales:sales /app
+USER sales
+
+EXPOSE ${PORT}
+HEALTHCHECK CMD curl -fsS http://localhost:${PORT}/_stcore/health || exit 1
+ENTRYPOINT ["sh", "-c", "streamlit run app/ui.py --server.port=${PORT} --server.address=0.0.0.0"]
+

--- a/cloudrun/cloudrun.yaml
+++ b/cloudrun/cloudrun.yaml
@@ -1,0 +1,18 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: sales-saas
+spec:
+  template:
+    spec:
+      containers:
+        - image: gcr.io/PROJECT_ID/sales-saas:latest
+          env:
+            - name: APP_ENV
+              value: "production"
+            - name: DATA_DIR
+              value: "/tmp"
+            - name: PORT
+              value: "8080"
+          ports:
+            - containerPort: 8080


### PR DESCRIPTION
## Summary
- add `cloudrun/` directory with Dockerfile and Cloud Run YAML
- document Cloud Run deployment steps and command
- provide `deploy-cloudrun` Makefile target

## Testing
- `pytest -q`
- `make docker-build` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b257b0e9a883338a5c248e3d02ccf8