### PR TITLE
Integrate search enhancer into UI with JSON schema enforcement

### DIFF
--- a/prompts/search_enhancement.yaml
+++ b/prompts/search_enhancement.yaml
@@ -13,18 +13,27 @@ query_optimization:
     目的: {purpose}
     
     最適化されたクエリを3つ提案し、それぞれの理由を説明してください。
-  
-  response_format: |
-    {
-      "optimized_queries": [
-        {
-          "query": "最適化されたクエリ1",
-          "reason": "最適化の理由",
-          "expected_improvement": "期待される改善効果"
-        }
-      ],
-      "search_strategy": "検索戦略の説明"
-    }
+  schema:
+    type: object
+    properties:
+      optimized_queries:
+        type: array
+        items:
+          type: object
+          properties:
+            query:
+              type: string
+            reason:
+              type: string
+            expected_improvement:
+              type: string
+          required: [query, reason, expected_improvement]
+          additionalProperties: false
+        minItems: 1
+      search_strategy:
+        type: string
+    required: [optimized_queries, search_strategy]
+    additionalProperties: false
 
 ## 検索結果の品質評価
 quality_assessment:
@@ -39,22 +48,37 @@ quality_assessment:
     
     各結果について、信頼性、関連性、時効性の観点から評価し、
     総合スコアを算出してください。
-  
-  response_format: |
-    {
-      "quality_scores": [
-        {
-          "url": "結果のURL",
-          "reliability_score": 0.0-1.0,
-          "relevance_score": 0.0-1.0,
-          "freshness_score": 0.0-1.0,
-          "overall_score": 0.0-1.0,
-          "reasoning": "評価の根拠",
-          "improvement_suggestions": ["改善提案1", "改善提案2"]
-        }
-      ],
-      "overall_assessment": "全体評価と改善提案"
-    }
+  schema:
+    type: object
+    properties:
+      quality_scores:
+        type: array
+        items:
+          type: object
+          properties:
+            url:
+              type: string
+            reliability_score:
+              type: number
+            relevance_score:
+              type: number
+            freshness_score:
+              type: number
+            overall_score:
+              type: number
+            reasoning:
+              type: string
+            improvement_suggestions:
+              type: array
+              items:
+                type: string
+          required: [url, reliability_score, relevance_score, freshness_score, overall_score, reasoning, improvement_suggestions]
+          additionalProperties: false
+        minItems: 1
+      overall_assessment:
+        type: string
+    required: [quality_scores, overall_assessment]
+    additionalProperties: false
 
 ## 業界別検索戦略
 industry_search_strategy:

--- a/services/search_enhancer.py
+++ b/services/search_enhancer.py
@@ -54,25 +54,19 @@ class SearchEnhancerService:
             user_prompt = prompt["user"].format(
                 original_query=original_query,
                 industry=industry or "未指定",
-                purpose=purpose or "一般的な調査"
+                purpose=purpose or "一般的な調査",
             )
             full_prompt = f"{prompt['system']}\n{user_prompt}"
 
             if not self.llm_provider:
                 return self._fallback_query_optimization(original_query, industry)
 
-            response = self.llm_provider.call_llm(full_prompt, "speed")
-            content = response.get("content", "")
-
-            try:
-                return json.loads(content)
-            except json.JSONDecodeError:
-                return self._fallback_query_optimization(original_query, industry)
+            schema = prompt.get("schema")
+            return self.llm_provider.call_llm(full_prompt, "speed", json_schema=schema)
 
         except Exception as e:
             self.error_handler.handle_error(f"クエリ最適化に失敗: {e}")
             return {"error": f"クエリ最適化に失敗: {e}"}
-    
     def _fallback_query_optimization(self, query: str, industry: str) -> Dict[str, Any]:
         """フォールバック用のクエリ最適化"""
         # 基本的なクエリ最適化ロジック
@@ -132,18 +126,12 @@ class SearchEnhancerService:
             if not self.llm_provider:
                 return self._fallback_quality_assessment(query, search_results)
 
-            response = self.llm_provider.call_llm(full_prompt, "deep")
-            content = response.get("content", "")
-
-            try:
-                return json.loads(content)
-            except json.JSONDecodeError:
-                return self._fallback_quality_assessment(query, search_results)
+            schema = prompt.get("schema")
+            return self.llm_provider.call_llm(full_prompt, "deep", json_schema=schema)
 
         except Exception as e:
             self.error_handler.handle_error(f"品質評価に失敗: {e}")
             return {"error": f"品質評価に失敗: {e}"}
-    
     def _fallback_quality_assessment(self, query: str, search_results: List[Dict[str, Any]]) -> Dict[str, Any]:
         """フォールバック用の品質評価"""
         quality_scores = []

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -84,7 +84,7 @@ def test_search_enhancer_calls_llm():
     """検索高度化サービスがLLMを呼び出すことを確認"""
     with patch('services.search_enhancer.OpenAIProvider') as mock_provider:
         mock_llm = Mock()
-        mock_llm.call_llm.return_value = {"content": json.dumps({"optimized_queries": [], "search_strategy": ""})}
+        mock_llm.call_llm.return_value = {"optimized_queries": [], "search_strategy": ""}
         mock_provider.return_value = mock_llm
 
         service = SearchEnhancerService()
@@ -92,8 +92,9 @@ def test_search_enhancer_calls_llm():
 
         assert "optimized_queries" in result
         mock_llm.call_llm.assert_called_once()
-        args, _ = mock_llm.call_llm.call_args
+        args, kwargs = mock_llm.call_llm.call_args
         assert args[1] == "speed"
+        assert "json_schema" in kwargs
 
 
 def test_search_enhancer_without_api_key():


### PR DESCRIPTION
## Summary
- Enforce JSON schema output for search query optimization and quality assessment prompts
- Call search enhancer from Streamlit UI to show card-based results and quality metrics
- Warn in UI when CSE_API_KEY or NEWSAPI_KEY is missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b25986cac08333bcfb82618e2368b3