### PR TITLE
docs: document storage and search env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,20 @@ chmod +x start_local.sh
 APP_ENV=local
 OPENAI_API_KEY=sk-xxxx
 DATA_DIR=./data
-STORAGE_PROVIDER=local  # local|gcs
+STORAGE_PROVIDER=local  # local|gcs|firestore
 GCS_BUCKET_NAME=        # required when STORAGE_PROVIDER=gcs
 GCS_PREFIX=sessions     # optional prefix path
-SEARCH_PROVIDER=none   # none|cse|newsapi 等
-CSE_API_KEY=
-CSE_CX=
+FIRESTORE_TENANT_ID=    # required when STORAGE_PROVIDER=firestore
+GOOGLE_APPLICATION_CREDENTIALS=path/to/cred.json  # required when STORAGE_PROVIDER=firestore
+SEARCH_PROVIDER=none   # none|cse|newsapi|hybrid
+CSE_API_KEY=            # required when SEARCH_PROVIDER=cse or hybrid
+CSE_CX=                 # required when SEARCH_PROVIDER=cse or hybrid
+NEWSAPI_KEY=            # required when SEARCH_PROVIDER=newsapi or hybrid
 ```
 
-`STORAGE_PROVIDER` を `gcs` に設定する場合は、`GCS_BUCKET_NAME`（必須）と必要に応じて `GCS_PREFIX` を指定してください。ローカルからGCSにアクセスする際は `GOOGLE_APPLICATION_CREDENTIALS` にサービスアカウントJSONのパスを設定します。
+`STORAGE_PROVIDER` を `gcs` に設定する場合は `GCS_BUCKET_NAME`（必須）と必要に応じて `GCS_PREFIX` を、`firestore` に設定する場合は `FIRESTORE_TENANT_ID` と `GOOGLE_APPLICATION_CREDENTIALS` を設定してください。ローカルからGCS/Firestore にアクセスする際は `GOOGLE_APPLICATION_CREDENTIALS` にサービスアカウントJSONのパスを設定します。
+
+`SEARCH_PROVIDER` を `cse` または `hybrid` に設定する場合は `CSE_API_KEY` と `CSE_CX` を、`newsapi` または `hybrid` に設定する場合は `NEWSAPI_KEY` をそれぞれ設定してください。
 
 ## GCPへの移行
 

--- a/env.example
+++ b/env.example
@@ -6,9 +6,10 @@ STORAGE_PROVIDER=local  # local|gcs|firestore
 GCS_BUCKET_NAME=          # required when STORAGE_PROVIDER=gcs
 GCS_PREFIX=sessions       # optional prefix path
 FIRESTORE_TENANT_ID=      # required when STORAGE_PROVIDER=firestore
-# GOOGLE_APPLICATION_CREDENTIALS=path/to/cred.json  # required when STORAGE_PROVIDER=firestore
-SEARCH_PROVIDER=none   # none|cse|newsapi 等
-CSE_API_KEY=
-CSE_CX=
-CRM_API_KEY=
+GOOGLE_APPLICATION_CREDENTIALS=  # required when STORAGE_PROVIDER=firestore
+SEARCH_PROVIDER=none   # none|cse|newsapi|hybrid
+CSE_API_KEY=              # required when SEARCH_PROVIDER=cse or hybrid
+CSE_CX=                   # required when SEARCH_PROVIDER=cse or hybrid
+NEWSAPI_KEY=              # required when SEARCH_PROVIDER=newsapi or hybrid
+CRM_API_KEY=              # required when using CRM integration
 


### PR DESCRIPTION
## Summary
- Expand environment variable docs for Firestore, GCS, and NewsAPI configuration
- Clarify when CSE and NEWSAPI keys are required for search providers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b26270e3cc833389e5210cf0d4037d