### PR TITLE
chore: update cloud run image path

### DIFF
--- a/cloudrun/cloudrun.yaml
+++ b/cloudrun/cloudrun.yaml
@@ -6,7 +6,8 @@ spec:
   template:
     spec:
       containers:
-        - image: gcr.io/PROJECT_ID/sales-saas:latest
+        - image: REGION-docker.pkg.dev/PROJECT_ID/REPOSITORY_NAME/sales-saas:latest
+          # Replace REGION, PROJECT_ID, and REPOSITORY_NAME with your Google Cloud settings.
           env:
             - name: APP_ENV
               value: "production"


### PR DESCRIPTION
## Summary
- switch Cloud Run service image to Artifact Registry path with REGION/PROJECT_ID/REPOSITORY_NAME placeholders
- add guidance comment for configuring REGION, PROJECT_ID, and REPOSITORY_NAME

## Testing
- `make deploy-cloudrun` *(fails: gcloud: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b263632228833399a997188e0c5a55