### PR TITLE
Add progress and decision documentation

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -541,8 +541,8 @@ chmod +x start_docker.sh
 
 ---
 
-- `docs/PROGRESS.md` を用意：日付/担当/フェーズ/完了・未完/次アクション/メモ を1セクション追記。
-- 重要な決定は `docs/DECISIONS.md`（ADR方式）に記録。番号付け。
+- 進捗は `docs/PROGRESS.md` に日付/担当/フェーズ/完了・未完/次アクション/メモで記録。
+- 重要な決定は `docs/DECISIONS.md`（ADR方式：番号/背景/決定/影響）に記録。
 - Issueテンプレ（GitHub）に「再現手順／期待結果／実結果」を必須化。
 
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ repo/
 - [ ] フェーズ9：Webリサーチ実装
 - [ ] フェーズ10：品質・セキュリティ
 
+## プロジェクトドキュメント
+
+- 進捗ログ: [docs/PROGRESS.md](docs/PROGRESS.md)
+- 重要な決定: [docs/DECISIONS.md](docs/DECISIONS.md)
+
 ## ライセンス
 
 MIT License

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,5 @@
+# Decision Log
+
+| number | context                     | decision                                              | consequences                                   |
+|--------|-----------------------------|-------------------------------------------------------|-----------------------------------------------|
+| 1      | Need structured tracking    | Introduced docs/PROGRESS.md and docs/DECISIONS.md     | Centralizes project progress and decisions    |

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,5 @@
+# Progress Log
+
+| date       | owner | phase | status | next action         | notes          |
+|------------|-------|-------|--------|---------------------|----------------|
+| 2025-08-30 | agent | docs  | done   | start tracking use  | initial setup  |


### PR DESCRIPTION
## Summary
- Track work items in `docs/PROGRESS.md`
- Record architecture decisions in `docs/DECISIONS.md`
- Reference progress and decision docs in README and AGENT instructions

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b264c9412883338d513892999101f6