### PR TITLE
refactor: use pathlib for prompt path

### DIFF
--- a/services/pre_advisor.py
+++ b/services/pre_advisor.py
@@ -1,6 +1,7 @@
 import yaml
 import os
 import time
+from pathlib import Path
 from typing import Dict, Any
 from string import Template
 from core.models import SalesInput
@@ -32,19 +33,24 @@ class PreAdvisorService:
     
     def _load_prompt_template(self) -> Dict[str, Any]:
         """プロンプトテンプレートを読み込み"""
+        file_path = Path(__file__).resolve().parent.parent / "prompts" / "pre_advice.yaml"
         try:
-            with open("prompts/pre_advice.yaml", "r", encoding="utf-8") as f:
+            with open(file_path, "r", encoding="utf-8") as f:
                 template = yaml.safe_load(f)
                 self.logger.info("Prompt template loaded successfully")
                 return template
         except FileNotFoundError:
             error_msg = "プロンプトファイル 'prompts/pre_advice.yaml' が見つかりません"
             self.logger.error(error_msg)
-            raise ConfigurationError(error_msg, "file_not_found", {"file_path": "prompts/pre_advice.yaml"})
+            raise ConfigurationError(error_msg, "file_not_found", {"file_path": str(file_path)})
         except yaml.YAMLError as e:
             error_msg = f"プロンプトファイルの形式が正しくありません: {e}"
             self.logger.error(error_msg)
-            raise ConfigurationError(error_msg, "invalid_format", {"file_path": "prompts/pre_advice.yaml", "error": str(e)})
+            raise ConfigurationError(
+                error_msg,
+                "invalid_format",
+                {"file_path": str(file_path), "error": str(e)},
+            )
     
     def generate_advice(self, sales_input: SalesInput) -> Dict[str, Any]:
         """事前アドバイスを生成"""


### PR DESCRIPTION
## Summary
- refactor pre-advisor service to load prompt with `Path` for robust file resolution

## Testing
- `pytest tests/test_pre_advisor.py::TestPreAdvisorService::test_init_loads_prompt_template -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b26d9fc21083338018835291b662fa