### PR TITLE
feat: handle empty search results

### DIFF
--- a/tests/test_search_provider.py
+++ b/tests/test_search_provider.py
@@ -68,3 +68,12 @@ def test_scoring_freshness_and_trusted_domain():
     assert fresh["detailed_scoring"]["freshness"] > old["detailed_scoring"]["freshness"]
     assert "high_trusted_domain" in fresh["reasons"]
     assert "trusted_domain" not in old["reasons"]
+
+
+def test_search_none_provider_returns_message():
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setenv("SEARCH_PROVIDER", "none")
+        provider = WebSearchProvider()
+        results = provider.search("unknown", num=3)
+        assert len(results) == 1
+        assert results[0]["snippet"] == "ヒットしませんでした。別のキーワードで再検索してください。"


### PR DESCRIPTION
## Summary
- return a helpful message when web search yields no results
- cover empty-result behavior with a new test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b27877bee08333b62759146759eb0e