### PR TITLE
Add offline offline fallbacks and warning logs

### DIFF
--- a/data/pre_advice_stub.json
+++ b/data/pre_advice_stub.json
@@ -1,0 +1,15 @@
+{
+  "short_term": {
+    "openers": {"call": "オフライン", "visit": "オフライン", "email": "オフライン"},
+    "discovery": ["オフライン"],
+    "differentiation": [{"vs": "オフライン", "talk": "オフライン"}],
+    "objections": [{"type": "オフライン", "script": "オフライン"}],
+    "next_actions": ["オフライン"],
+    "kpi": {"next_meeting_rate": "0%", "poc_rate": "0%"},
+    "summary": "オフラインスタブ"
+  },
+  "mid_term": {
+    "plan_weeks_4_12": ["オフライン"]
+  },
+  "offline": true
+}

--- a/data/search_cache.json
+++ b/data/search_cache.json
@@ -1,0 +1,13 @@
+{
+  "IT 最新ニュース": [
+    {
+      "title": "キャッシュニュース",
+      "url": "https://example.com/offline",
+      "snippet": "オフラインキャッシュからのニュース",
+      "source": "cache",
+      "published_at": null,
+      "score": 1.0,
+      "reasons": ["cache"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- provide WebSearchProvider offline mode with cached or stub results and warning logs
- allow PreAdvisorService to fall back to local stub when LLM access fails
- add offline fallback unit test and stub data files

## Testing
- `pytest tests/test_pre_advisor.py::TestPreAdvisorService::test_offline_fallback -q`
- `pytest tests/test_pre_advisor.py -q`
- `pytest tests/test_search_provider.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2794aa3cc8333a1aab8a07ff7232e