### PR TITLE
feat: add header language dropdown

### DIFF
--- a/app/ui.py
+++ b/app/ui.py
@@ -2,7 +2,7 @@ import os
 import streamlit as st
 from dotenv import load_dotenv
 from streamlit_javascript import st_javascript
-from translations import t
+from translations import t, get_language
 from services.settings_manager import SettingsManager
 
 # 環境変数を読み込み
@@ -53,7 +53,29 @@ def main():
                 width = 1000
         st.session_state.screen_width = width
 
-    st.title(t("app_title"))
+    current_lang = get_language()
+    lang_options = {
+        "ja": "\U0001F1EF\U0001F1F5 日本語",
+        "en": "\U0001F1FA\U0001F1F8 English",
+        "es": "\U0001F1EA\U0001F1F8 Español",
+    }
+    header_cols = st.columns([8, 2])
+    with header_cols[0]:
+        st.title(t("app_title"))
+    with header_cols[1]:
+        selected_lang = st.selectbox(
+            "language",
+            options=list(lang_options.keys()),
+            index=list(lang_options.keys()).index(current_lang),
+            format_func=lambda x: lang_options[x],
+            key="language_select",
+            label_visibility="collapsed",
+        )
+        if selected_lang != current_lang:
+            st.session_state["language"] = selected_lang
+            settings_manager.update_setting("language", selected_lang)
+            st.rerun()
+
     st.markdown("---")
 
     is_mobile = st.session_state.get("screen_width", 1000) < 700

--- a/tests/test_ui_language_switch.py
+++ b/tests/test_ui_language_switch.py
@@ -1,0 +1,21 @@
+import streamlit as st
+from pathlib import Path
+from services.settings_manager import SettingsManager
+from app import translations
+
+
+def test_language_switch_persists(tmp_path, monkeypatch):
+    config_file = tmp_path / "config" / "settings.json"
+    manager = SettingsManager(str(config_file))
+    monkeypatch.setattr(translations, "SettingsManager", lambda: manager)
+
+    st.session_state.clear()
+    assert translations.get_language() == "ja"
+
+    st.session_state["language"] = "en"
+    manager.update_setting("language", "en")
+    assert translations.t("menu") == "Menu"
+
+    st.session_state.clear()
+    assert translations.get_language() == "en"
+    assert translations.t("menu") == "Menu"


### PR DESCRIPTION
## Summary
- add language dropdown with flag icons to UI header
- persist language choice and expose test for language switching

## Testing
- `pytest tests/test_ui_language_switch.py`


------
https://chatgpt.com/codex/tasks/task_e_68b27c52e0648333952ecef0776b57bb