### PR TITLE
Add Firestore and Secret Manager env vars for Cloud Run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ docker-build:
 
 # Cloud Run へデプロイ
 deploy-cloudrun:
-	gcloud run services replace cloudrun/cloudrun.yaml --region=asia-northeast1
+	gcloud run services replace cloudrun/cloudrun.yaml --region=asia-northeast1 \
+		--set-env-vars="FIRESTORE_TENANT_ID=$(FIRESTORE_TENANT_ID),OPENAI_API_SECRET_NAME=$(OPENAI_API_SECRET_NAME),STORAGE_PROVIDER=firestore"
 
 # ヘルプ
 help:

--- a/README.md
+++ b/README.md
@@ -93,13 +93,20 @@ NEWSAPI_KEY=            # required when SEARCH_PROVIDER=newsapi or hybrid
 gcloud builds submit --tag asia-northeast1-docker.pkg.dev/$PROJECT_ID/sales-saas-repo/sales-saas
 ```
 
-2. Cloud Run サービスを更新:
+2. Firestore と Secret Manager 用の環境変数を設定してデプロイ:
 
 ```bash
+export FIRESTORE_TENANT_ID=tenant-123
+export OPENAI_API_SECRET_NAME=openai-api-key
 make deploy-cloudrun
 ```
 
-`cloudrun/cloudrun.yaml` にはポート `8080` と GCP 用環境変数が定義されています。
+3. Cloud Run 実行サービスアカウントに必要な権限を付与:
+
+- `roles/datastore.user` (Firestore アクセス)
+- `roles/secretmanager.secretAccessor` (Secret Manager アクセス)
+
+`cloudrun/cloudrun.yaml` にはポート `8080` と上記の環境変数が定義されています。
 
 ## LLMプロバイダのJSONスキーマ対応
 

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -391,3 +391,22 @@
 ### Testing
 - `pytest -q`
 - Environment: Python 3.12.10, streamlit==1.49.1, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1
+
+## 2025-09-20
+### Task
+- Cloud Run 用 YAML に Firestore/Secret Manager の環境変数を追加し、デプロイスクリプトを更新
+  - refs: [cloudrun/cloudrun.yaml, Makefile]
+- Cloud Run セクションにデプロイ手順と権限設定を追記
+  - refs: [README.md]
+- 進捗ログを更新
+  - refs: [docs/PROGRESS.md]
+
+### Reviews
+1. **Python上級エンジニア視点**: デプロイ設定がコード化され、環境変数の追跡が容易に。
+2. **UI/UX専門家視点**: README に手順が明記され、利用者が迷わず Cloud Run を構築できる。
+3. **クラウドエンジニア視点**: Firestore と Secret Manager の権限が明示され、運用ミスを防げる。
+4. **ユーザー視点**: クラウド上でも安全にデータ保存と鍵管理が行われる安心感が得られる。
+
+### Testing
+- `pytest -q`
+- Environment: Python 3.12.10, streamlit==1.49.1, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1

--- a/cloudrun/cloudrun.yaml
+++ b/cloudrun/cloudrun.yaml
@@ -15,5 +15,11 @@ spec:
               value: "/tmp"
             - name: PORT
               value: "8080"
+            - name: STORAGE_PROVIDER
+              value: "firestore"
+            - name: FIRESTORE_TENANT_ID
+              value: "tenant-123"
+            - name: OPENAI_API_SECRET_NAME
+              value: "openai-api-key"
           ports:
             - containerPort: 8080

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -4,3 +4,4 @@
 |------------|-------|-------|--------|---------------------|----------------|
 | 2025-08-30 | agent | docs  | done   | start tracking use  | initial setup  |
 | 2025-09-17 | agent | phase8 | done   | verify gcp storage  | firestore support |
+| 2025-09-20 | agent | phase8 | done   | confirm secret access | added Cloud Run env vars |


### PR DESCRIPTION
## Summary
- configure Cloud Run service with Firestore and Secret Manager environment variables
- pass Firestore tenant and secret name via `deploy-cloudrun` target
- document Cloud Run deployment and required IAM roles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b29077eafc8333808fb503c3ccf632