### PR TITLE
feat: add mobile menu aria label

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -410,3 +410,18 @@
 ### Testing
 - `pytest -q`
 - Environment: Python 3.12.10, streamlit==1.49.1, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1
+
+## 2025-09-22
+### Task
+- モバイルメニューのトグルボタンをカスタムHTMLに置き換え、`aria-label="メニュー"` を付与
+  - refs: [app/ui.py]
+
+### Reviews
+1. **Python上級エンジニア視点**: JSを介したクリックイベント処理とステート管理が明示化され、保守が容易。
+2. **UI/UX専門家視点**: スクリーンリーダーがメニューを正しく読み上げ、アクセシビリティが向上。
+3. **クラウドエンジニア視点**: DOM操作はクライアントサイドのみで完結し、デプロイ構成に影響しない。
+4. **ユーザー視点**: ハンバーガーメニューがより直感的に操作でき、モバイル体験が改善。
+
+### Testing
+- `pytest -q`
+- Environment: Python 3.12.10, streamlit==1.49.1, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1

--- a/app/ui.py
+++ b/app/ui.py
@@ -92,12 +92,24 @@ def main():
         # ハンバーガーメニューでサイドバーをトグル表示
         cols = st.columns([1, 9])
         with cols[0]:
-            if st.button(
-                t("sidebar_toggle_label"),
-                help=t("sidebar_toggle_help"),
-                key="menu_toggle",
-            ):
+            st.markdown(
+                f'<button id="menu-toggle" aria-label="メニュー">{t("sidebar_toggle_label")}</button>',
+                unsafe_allow_html=True,
+            )
+            clicked_ts = st_javascript(
+                """
+                const btn = document.getElementById('menu-toggle');
+                if (btn) {
+                    btn.setAttribute('aria-label', 'メニュー');
+                    btn.onclick = () => Streamlit.setComponentValue(Date.now());
+                }
+                """,
+                key="menu_toggle_js",
+            )
+            last_clicked = st.session_state.get("menu_toggle_last")
+            if clicked_ts and clicked_ts != last_clicked:
                 st.session_state.show_sidebar = not st.session_state.show_sidebar
+                st.session_state.menu_toggle_last = clicked_ts
             # aria-label: toggle navigation menu
 
         if st.session_state.show_sidebar:


### PR DESCRIPTION
## Summary
- replace mobile menu toggle button with custom HTML that includes `aria-label="メニュー"`
- use streamlit_javascript to assign the aria label and handle toggle events
- log the change in WORKLOG

## Testing
- `pytest -q`
- `streamlit run app/ui.py --server.headless true --server.port 8502`

------
https://chatgpt.com/codex/tasks/task_e_68b2c2ff5eb483339f2c8c14b41bb8bf