### PR TITLE
feat: sanitize prompt inputs

### DIFF
--- a/services/icebreaker.py
+++ b/services/icebreaker.py
@@ -4,7 +4,7 @@ from string import Template
 from core.models import SalesType
 from providers.llm_openai import OpenAIProvider
 from providers.search_provider import WebSearchProvider
-from services.utils import escape_braces
+from services.utils import escape_braces, sanitize_for_prompt
 
 class IcebreakerService:
     def __init__(self, settings_manager=None):
@@ -89,19 +89,20 @@ class IcebreakerService:
         if news_items:
             news_details = "\n".join(
                 [
-                    f"- {escape_braces(item['title'])}: {escape_braces(item['snippet'])}"
+                    f"- {escape_braces(sanitize_for_prompt(item['title']))}: {escape_braces(sanitize_for_prompt(item['snippet']))}"
                     for item in news_items
                 ]
             )
+            news_details = sanitize_for_prompt(news_details)
 
         # ユーザーメッセージ
         user_template = Template(self.prompt_template["user_template"])
         user_msg = user_template.safe_substitute(
-            sales_type=escape_braces(sales_type.value),
-            tone=escape_braces(tone),
-            industry=escape_braces(industry),
-            company_hint=escape_braces(company_hint or 'なし'),
-            news_items=escape_braces(news_details),
+            sales_type=escape_braces(sanitize_for_prompt(sales_type.value)),
+            tone=escape_braces(sanitize_for_prompt(tone)),
+            industry=escape_braces(sanitize_for_prompt(industry)),
+            company_hint=escape_braces(sanitize_for_prompt(company_hint or 'なし')),
+            news_items=escape_braces(sanitize_for_prompt(news_details)),
         )
 
         # 出力制約

--- a/services/post_analyzer.py
+++ b/services/post_analyzer.py
@@ -8,6 +8,7 @@ from core.models import SalesType
 from providers.llm_openai import OpenAIProvider
 from services.error_handler import ServiceError, ConfigurationError
 from services.logger import Logger
+from services.utils import escape_braces, sanitize_for_prompt
 
 logger = Logger("PostAnalyzerService")
 
@@ -120,14 +121,19 @@ class PostAnalyzerService:
             raise ConfigurationError("プロンプトテンプレートが読み込まれていません")
         
         # テンプレートの置換
+        meeting_content_clean = escape_braces(sanitize_for_prompt(meeting_content))
+        sales_type_clean = escape_braces(sanitize_for_prompt(sales_type.value))
+        industry_clean = escape_braces(sanitize_for_prompt(industry))
+        product_clean = escape_braces(sanitize_for_prompt(product))
+
         prompt = self.prompt_template['system'] + "\n\n"
         prompt += self.prompt_template['user'].format(
-            meeting_content=meeting_content,
-            sales_type=sales_type.value,
-            industry=industry,
-            product=product
+            meeting_content=meeting_content_clean,
+            sales_type=sales_type_clean,
+            industry=industry_clean,
+            product=product_clean
         )
-        
+
         return prompt
     
     def _get_analysis_schema(self) -> Dict[str, Any]:

--- a/services/pre_advisor.py
+++ b/services/pre_advisor.py
@@ -11,7 +11,7 @@ from providers.llm_openai import OpenAIProvider
 from providers.search_provider import WebSearchProvider
 from services.logger import Logger
 from services.error_handler import ErrorHandler, ServiceError, ConfigurationError
-from services.utils import escape_braces
+from services.utils import escape_braces, sanitize_for_prompt
 
 class PreAdvisorService:
     def __init__(self, settings_manager=None):
@@ -164,30 +164,32 @@ class PreAdvisorService:
     def _build_prompt(self, sales_input: SalesInput) -> str:
         """プロンプトを構築"""
         # 説明フィールドの処理
-        description = escape_braces(sales_input.description or "")
-        description_url = escape_braces(sales_input.description_url or "")
+        description = escape_braces(sanitize_for_prompt(sales_input.description or ""))
+        description_url = escape_braces(sanitize_for_prompt(sales_input.description_url or ""))
 
         # 競合フィールドの処理
-        competitor = escape_braces(sales_input.competitor or "")
-        competitor_url = escape_braces(sales_input.competitor_url or "")
+        competitor = escape_braces(sanitize_for_prompt(sales_input.competitor or ""))
+        competitor_url = escape_braces(sanitize_for_prompt(sales_input.competitor_url or ""))
 
         # 制約の処理
         constraints_text = escape_braces(
-            ", ".join(sales_input.constraints) if sales_input.constraints else "なし"
+            sanitize_for_prompt(
+                ", ".join(sales_input.constraints) if sales_input.constraints else "なし"
+            )
         )
 
         # プロンプトテンプレートを適用
         user_template = Template(self.prompt_template["user"])
         prompt = user_template.safe_substitute(
-            sales_type=escape_braces(sales_input.sales_type.value),
-            industry=escape_braces(sales_input.industry),
-            product=escape_braces(sales_input.product),
+            sales_type=escape_braces(sanitize_for_prompt(sales_input.sales_type.value)),
+            industry=escape_braces(sanitize_for_prompt(sales_input.industry)),
+            product=escape_braces(sanitize_for_prompt(sales_input.product)),
             description=description,
             description_url=description_url,
             competitor=competitor,
             competitor_url=competitor_url,
-            stage=escape_braces(sales_input.stage),
-            purpose=escape_braces(sales_input.purpose),
+            stage=escape_braces(sanitize_for_prompt(sales_input.stage)),
+            purpose=escape_braces(sanitize_for_prompt(sales_input.purpose)),
             constraints=constraints_text,
         )
 

--- a/services/utils.py
+++ b/services/utils.py
@@ -3,6 +3,20 @@ from __future__ import annotations
 import re
 
 
+def sanitize_for_prompt(text: str) -> str:
+    """Remove potentially dangerous prompt directives and HTML tags.
+
+    This helps mitigate prompt injection by stripping markers like
+    ``system:`` or ``assistant:`` and removing any HTML tags that may carry
+    embedded instructions.
+    """
+    if not isinstance(text, str):
+        return text
+    sanitized = re.sub(r"(?i)\b(system|assistant)\s*:", "", text)
+    sanitized = re.sub(r"<[^>]*>", "", sanitized)
+    return sanitized.strip()
+
+
 def escape_braces(text: str) -> str:
     """Escape curly braces in the given text for safe formatting.
 

--- a/tests/test_icebreaker.py
+++ b/tests/test_icebreaker.py
@@ -116,6 +116,26 @@ class TestIcebreakerService:
         )
         assert "I{T}" in prompt
         assert "Comp{any}" in prompt
+
+    def test_build_prompt_sanitizes_input(self):
+        service = self.service
+        service.prompt_template = {
+            "system": "sys",
+            "user_template": "業界: $industry\n会社ヒント: $company_hint",
+            "output_constraints": []
+        }
+        prompt = service._build_prompt(
+            SalesType.HUNTER,
+            industry="<b>IT</b> system:",
+            company_hint="assistant: <i>hint</i>",
+            news_items=[],
+            tone="tone",
+        )
+        assert "<" not in prompt and ">" not in prompt
+        assert "system:" not in prompt.lower()
+        assert "assistant:" not in prompt.lower()
+        assert "IT" in prompt
+        assert "hint" in prompt
     
     def test_get_tone_for_type(self):
         """営業タイプ別トーンの取得テスト"""

--- a/tests/test_post_analyzer.py
+++ b/tests/test_post_analyzer.py
@@ -79,6 +79,22 @@ class TestPostAnalyzerService:
         assert "consultant" in prompt
         assert "IT業界" in prompt
         assert "SaaS" in prompt
+
+    def test_build_prompt_sanitizes_input(self):
+        service = PostAnalyzerService()
+        prompt = service._build_prompt(
+            meeting_content="<b>内容</b> system:",
+            sales_type=SalesType.HUNTER,
+            industry="assistant: <i>IT</i>",
+            product="<script>bad</script>"
+        )
+
+        assert "<" not in prompt and ">" not in prompt
+        assert "system:" not in prompt.lower()
+        assert "assistant:" not in prompt.lower()
+        assert "内容" in prompt
+        assert "IT" in prompt
+        assert "bad" in prompt
     
     def test_build_prompt_without_template(self):
         """プロンプトテンプレートなしでの構築"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from services.utils import escape_braces, mask_pii
+from services.utils import escape_braces, mask_pii, sanitize_for_prompt
 
 
 def test_escape_braces():
@@ -12,3 +12,12 @@ def test_mask_pii():
     assert mask_pii('Call me at 090-1234-5678') == 'Call me at ***'
     assert mask_pii('John Doe logged in') == '*** logged in'
     assert mask_pii('山田太郎が参加') == '***が参加'
+
+
+def test_sanitize_for_prompt():
+    malicious = "system: <b>Hello</b> assistant:<script>alert(1)</script>"
+    result = sanitize_for_prompt(malicious)
+    assert 'system:' not in result.lower()
+    assert 'assistant:' not in result.lower()
+    assert '<' not in result and '>' not in result
+    assert 'alert(1)' in result


### PR DESCRIPTION
## Summary
- add `sanitize_for_prompt` utility to strip HTML and role keywords from user text
- apply prompt sanitization across PreAdvisor, PostAnalyzer and Icebreaker services
- extend unit tests to cover malicious input handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2c6d03c9c833382cb205d5ef4ed3d