### PR TITLE
refactor: return session id from icebreaker save

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -425,3 +425,19 @@
 ### Testing
 - `pytest -q`
 - Environment: Python 3.12.10, streamlit==1.49.1, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1
+
+## 2025-09-23
+### Task
+- セッション保存関数が `session_id` を返し、保存ボタンでその ID を表示するよう修正
+  - refs: [app/pages/icebreaker.py]
+
+### Reviews
+1. **Python上級エンジニア視点**: `session_id` の返却で外部からのハンドリングが明確になり、テスト可能性が向上。
+2. **UI/UX専門家視点**: 保存成功メッセージが一度だけ表示され、ユーザーの混乱を防げる。
+3. **クラウドエンジニア視点**: セッションIDが明示されることでログ追跡が容易になり、デバッグ効率が向上。
+4. **ユーザー視点**: セッションIDが表示されることで、後から履歴を参照する際の安心感が増す。
+
+### Testing
+- `make lint`
+- `pytest -q`
+- Environment: Python 3.12.10, streamlit==1.49.1, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1

--- a/app/pages/icebreaker.py
+++ b/app/pages/icebreaker.py
@@ -185,8 +185,9 @@ def display_icebreakers(sales_type: SalesType, industry: str, icebreakers: list,
     col1, col2 = st.columns([1, 1])
     with col1:
         if st.button("💾 セッションに保存", use_container_width=True):
-            save_icebreakers(sales_type, industry, icebreakers, company_hint, search_enabled)
-            st.success("アイスブレイクをセッションに保存しました！セッションID: {session_id[:8]}...")
+            session_id = save_icebreakers(sales_type, industry, icebreakers, company_hint, search_enabled)
+            if session_id:
+                st.success(f"アイスブレイクをセッションに保存しました！セッションID: {session_id[:8]}...")
     
     with col2:
         if st.button("📥 JSONでダウンロード", use_container_width=True):
@@ -270,11 +271,8 @@ def save_icebreakers(sales_type: SalesType, industry: str, icebreakers: list, co
         # セッション状態に保存
         if "icebreaker_sessions" not in st.session_state:
             st.session_state.icebreaker_sessions = {}
-        
+
         st.session_state.icebreaker_sessions[session_id] = session_data
-        
-        # 成功メッセージ
-        st.success(f"アイスブレイクをセッションに保存しました！セッションID: {session_id[:8]}...")
         
         # 履歴ページで表示できるように保存
         try:
@@ -302,9 +300,12 @@ def save_icebreakers(sales_type: SalesType, industry: str, icebreakers: list, co
 
         except Exception as storage_error:
             st.warning(f"履歴への保存に失敗しました: {storage_error}")
-        
+
+        return session_id
+
     except Exception as e:
         st.error(f"保存に失敗しました: {e}")
+        return None
 
 def download_icebreakers_json(sales_type: SalesType, industry: str, icebreakers: list, company_hint: str = None, search_enabled: bool = True):
     """アイスブレイク結果をJSONファイルでダウンロード"""

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -5,3 +5,4 @@
 | 2025-08-30 | agent | docs  | done   | start tracking use  | initial setup  |
 | 2025-09-17 | agent | phase8 | done   | verify gcp storage  | firestore support |
 | 2025-09-20 | agent | phase8 | done   | confirm secret access | added Cloud Run env vars |
+| 2025-09-23 | agent | phase8 | done   | verify session save   | return session id |


### PR DESCRIPTION
## Summary
- return generated `session_id` from `save_icebreakers`
- display save message using returned `session_id` and avoid double success alerts
- record change in progress and work logs

## Testing
- `make lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2cf878a6c8333ba04261b531177a8