### PR TITLE
feat: enhance prompt sanitizer

### DIFF
--- a/services/utils.py
+++ b/services/utils.py
@@ -4,16 +4,34 @@ import re
 
 
 def sanitize_for_prompt(text: str) -> str:
-    """Remove potentially dangerous prompt directives and HTML tags.
+    """Remove potentially dangerous prompt directives and unwanted characters.
 
-    This helps mitigate prompt injection by stripping markers like
-    ``system:`` or ``assistant:`` and removing any HTML tags that may carry
-    embedded instructions.
+    This helper strips role markers like ``system:`` or ``developer:``, HTML
+    tags, backticks, and zero-width characters. After cleaning, only
+    alphanumeric characters, whitespace, and common punctuation remain to
+    prevent prompt injections.
     """
     if not isinstance(text, str):
         return text
-    sanitized = re.sub(r"(?i)\b(system|assistant)\s*:", "", text)
+
+    # remove role keywords such as ``system:``, ``assistant:``, ``user:``, ``developer:``
+    sanitized = re.sub(r"(?i)\b(?:system|assistant|user|developer)\s*:", "", text)
+
+    # strip HTML tags completely
     sanitized = re.sub(r"<[^>]*>", "", sanitized)
+
+    # remove backticks and markdown code fences
+    sanitized = sanitized.replace("`", "")
+
+    # remove zero-width and other invisible unicode characters
+    sanitized = re.sub(r"[\u200B-\u200F\u202A-\u202E\u2060\uFEFF]", "", sanitized)
+
+    # whitelist: allow only alphanumerics, whitespace, and common punctuation
+    sanitized = re.sub(r"[^0-9A-Za-z\s.,!?;:'\"()\-_/]", "", sanitized)
+
+    # collapse consecutive whitespace to a single space
+    sanitized = re.sub(r"\s+", " ", sanitized)
+
     return sanitized.strip()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,3 +21,26 @@ def test_sanitize_for_prompt():
     assert 'assistant:' not in result.lower()
     assert '<' not in result and '>' not in result
     assert 'alert(1)' in result
+
+
+def test_sanitize_for_prompt_removes_all_role_keywords():
+    text = "User: greet Developer: fix System: set Assistant: help"
+    result = sanitize_for_prompt(text)
+    lowered = result.lower()
+    for role in ("user:", "developer:", "system:", "assistant:"):
+        assert role not in lowered
+    assert result == "greet fix set help"
+
+
+def test_sanitize_for_prompt_removes_invisible_and_backticks():
+    text = "Here\u200b is `code` and ```block```"
+    result = sanitize_for_prompt(text)
+    assert "\u200b" not in result
+    assert "`" not in result
+    assert result == "Here is code and block"
+
+
+def test_sanitize_for_prompt_whitelists_ascii():
+    text = "Hello\u263a\u4e16\u754c!"  # Hello🙂世界!
+    result = sanitize_for_prompt(text)
+    assert result == "Hello!"


### PR DESCRIPTION
## Summary
- broaden `sanitize_for_prompt` to strip role markers, backticks, invisible characters and whitelist safe punctuation
- add comprehensive tests covering new sanitization behavior

## Testing
- `pytest tests/test_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2e01059248333a3b7b045e4b055ad