### PR TITLE
Use safe Template substitution for search enhancer prompts

### DIFF
--- a/prompts/search_enhancement.yaml
+++ b/prompts/search_enhancement.yaml
@@ -8,9 +8,9 @@ query_optimization:
   
   user: |
     以下の検索クエリを最適化してください：
-    元のクエリ: {original_query}
-    業界: {industry}
-    目的: {purpose}
+    元のクエリ: ${original_query}
+    業界: ${industry}
+    目的: ${purpose}
     
     最適化されたクエリを3つ提案し、それぞれの理由を説明してください。
   schema:
@@ -43,8 +43,8 @@ quality_assessment:
   
   user: |
     以下の検索結果を品質評価してください：
-    検索クエリ: {query}
-    検索結果: {search_results}
+    検索クエリ: ${query}
+    検索結果: ${search_results}
     
     各結果について、信頼性、関連性、時効性の観点から評価し、
     総合スコアを算出してください。
@@ -88,9 +88,9 @@ industry_search_strategy:
   
   user: |
     以下の業界について、最適な検索戦略を提案してください：
-    業界: {industry}
-    検索目的: {purpose}
-    対象期間: {time_period}
+    業界: ${industry}
+    検索目的: ${purpose}
+    対象期間: ${time_period}
     
     信頼できる情報源、キーワード戦略、時効性の考慮事項を含めて
     包括的な検索戦略を提案してください。
@@ -117,8 +117,8 @@ result_integration:
   
   user: |
     以下の検索結果を統合・要約してください：
-    検索クエリ: {query}
-    検索結果: {search_results}
+    検索クエリ: ${query}
+    検索結果: ${search_results}
     
     主要な洞察、トレンド、機会、リスクを抽出し、
     アクション可能な推奨事項を提示してください。
@@ -149,9 +149,9 @@ continuous_improvement:
   
   user: |
     検索品質の継続改善について、以下の観点から戦略を提案してください：
-    現在の課題: {current_challenges}
-    目標: {improvement_goals}
-    利用可能なリソース: {available_resources}
+    現在の課題: ${current_challenges}
+    目標: ${improvement_goals}
+    利用可能なリソース: ${available_resources}
     
     短期的な改善策、長期的な戦略、測定可能な指標を含めて
     包括的な改善計画を提案してください。

--- a/services/utils.py
+++ b/services/utils.py
@@ -4,34 +4,22 @@ import re
 
 
 def sanitize_for_prompt(text: str) -> str:
-    """Remove potentially dangerous prompt directives and unwanted characters.
+    """Remove potentially dangerous prompt directives and HTML tags.
 
-    This helper strips role markers like ``system:`` or ``developer:``, HTML
-    tags, backticks, and zero-width characters. After cleaning, only
-    alphanumeric characters, whitespace, and common punctuation remain to
-    prevent prompt injections.
+    This helper strips role markers like ``system:``, ``assistant:``,
+    ``user:``, or ``developer:``, removes HTML tags, and eliminates
+    backticks or zero-width characters while preserving other text such as
+    braces or non-ASCII characters.
     """
     if not isinstance(text, str):
         return text
 
-    # remove role keywords such as ``system:``, ``assistant:``, ``user:``, ``developer:``
     sanitized = re.sub(r"(?i)\b(?:system|assistant|user|developer)\s*:", "", text)
-
-    # strip HTML tags completely
     sanitized = re.sub(r"<[^>]*>", "", sanitized)
-
-    # remove backticks and markdown code fences
     sanitized = sanitized.replace("`", "")
-
-    # remove zero-width and other invisible unicode characters
     sanitized = re.sub(r"[\u200B-\u200F\u202A-\u202E\u2060\uFEFF]", "", sanitized)
-
-    # whitelist: allow only alphanumerics, whitespace, and common punctuation
-    sanitized = re.sub(r"[^0-9A-Za-z\s.,!?;:'\"()\-_/]", "", sanitized)
-
-    # collapse consecutive whitespace to a single space
+    sanitized = re.sub(r"[\u2600-\u27BF]", "", sanitized)
     sanitized = re.sub(r"\s+", " ", sanitized)
-
     return sanitized.strip()
 
 

--- a/tests/test_search_enhancer.py
+++ b/tests/test_search_enhancer.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from services.search_enhancer import SearchEnhancerService
+
+
+class DummyLLM:
+    def __init__(self) -> None:
+        self.last_prompt: str | None = None
+
+    def call_llm(self, prompt: str, mode: str, json_schema=None):
+        self.last_prompt = prompt
+        if json_schema and "optimized_queries" in json_schema.get("properties", {}):
+            return {"optimized_queries": [], "search_strategy": ""}
+        if json_schema and "quality_scores" in json_schema.get("properties", {}):
+            return {"quality_scores": [], "overall_assessment": ""}
+        return {}
+
+
+def test_enhance_query_sanitizes_braces_and_role():
+    llm = DummyLLM()
+    service = SearchEnhancerService(llm_provider=llm)
+
+    query = "system: {attack}"
+    result = service.enhance_search_query(query, industry="{IT}", purpose="{test}")
+
+    assert "error" not in result
+    assert llm.last_prompt is not None
+    assert "system:" not in llm.last_prompt
+    assert "attack" in llm.last_prompt
+    assert "{{attack}}" in llm.last_prompt
+    assert "{{IT}}" in llm.last_prompt
+
+
+def test_assess_quality_sanitizes_result_fields():
+    llm = DummyLLM()
+    service = SearchEnhancerService(llm_provider=llm)
+
+    query = "test {braces}"
+    results = [{"title": "Title {bad}", "snippet": "snippet system: x"}]
+    output = service.assess_search_quality(query, results)
+
+    assert "error" not in output
+    assert llm.last_prompt is not None
+    assert "system:" not in llm.last_prompt
+    assert "{{bad}}" in llm.last_prompt
+    assert "{{braces}}" in llm.last_prompt
+    assert "braces" in llm.last_prompt

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,4 +43,4 @@ def test_sanitize_for_prompt_removes_invisible_and_backticks():
 def test_sanitize_for_prompt_whitelists_ascii():
     text = "Hello\u263a\u4e16\u754c!"  # Hello🙂世界!
     result = sanitize_for_prompt(text)
-    assert result == "Hello!"
+    assert result == "Hello世界!"


### PR DESCRIPTION
## Summary
- sanitize search enhancer inputs via `sanitize_for_prompt` and `escape_braces`
- switch search enhancer prompts to `Template.safe_substitute`
- add sanitization tests including curly-brace queries and update utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b2e30e25e8833393181cc8f2c3e6f2