### PR TITLE
feat: add token usage tracking

### DIFF
--- a/services/usage_meter.py
+++ b/services/usage_meter.py
@@ -1,0 +1,26 @@
+import os
+from typing import Dict
+
+class UsageMeter:
+    """Simple in-memory usage meter for tracking token usage per user or tenant."""
+
+    _usage: Dict[str, int] = {}
+
+    @classmethod
+    def get_limit(cls, user_id: str | None = None) -> int:
+        """Retrieve token limit for a user from env var TOKEN_USAGE_LIMIT."""
+        return int(os.getenv("TOKEN_USAGE_LIMIT", "1000000"))
+
+    @classmethod
+    def add_tokens(cls, user_id: str, tokens: int) -> int:
+        total = cls._usage.get(user_id, 0) + tokens
+        cls._usage[user_id] = total
+        return total
+
+    @classmethod
+    def get_tokens(cls, user_id: str) -> int:
+        return cls._usage.get(user_id, 0)
+
+    @classmethod
+    def reset(cls):
+        cls._usage.clear()


### PR DESCRIPTION
## Summary
- add in-memory token usage meter
- enforce token limits in OpenAIProvider and raise LLMError
- test usage limit behavior

## Testing
- `pytest tests/test_llm_provider.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f3292a9c833388644c7c4587dd47