### PR TITLE
docs: add GCS tenant id configuration

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -93,10 +93,19 @@ pytest-mock>=3.14
 ```
 APP_ENV=local
 OPENAI_API_KEY=sk-xxxx
+OPENAI_MODEL=gpt-4o-mini
 DATA_DIR=./data
+STORAGE_PROVIDER=local  # local|gcs|firestore
+GCS_BUCKET_NAME=          # required when STORAGE_PROVIDER=gcs
+GCS_PREFIX=sessions       # optional prefix path
+GCS_TENANT_ID=tenant-123   # required when STORAGE_PROVIDER=gcs
+FIRESTORE_TENANT_ID=tenant-123   # required when STORAGE_PROVIDER=firestore
+GOOGLE_APPLICATION_CREDENTIALS=./gcp-credentials.json  # required when STORAGE_PROVIDER=firestore
 SEARCH_PROVIDER=none   # none|cse|newsapi 等
 CSE_API_KEY=
 CSE_CX=
+NEWSAPI_KEY=
+CRM_API_KEY=
 ```
 
 6. **Dockerfile（Python 3.11）**

--- a/GOOGLE_CLOUD_MIGRATION.md
+++ b/GOOGLE_CLOUD_MIGRATION.md
@@ -162,6 +162,7 @@ GCSにセッションを保存するため、以下の環境変数を設定し�
 - `STORAGE_PROVIDER=gcs`
 - `GCS_BUCKET_NAME`（必須）
 - `GCS_PREFIX`（任意、デフォルトは `sessions`）
+- `GCS_TENANT_ID`（必須）
 
 ```bash
 # 環境変数としてシークレットを追加
@@ -172,6 +173,7 @@ gcloud run services update sales-saas \
   --set-env-vars="STORAGE_PROVIDER=gcs" \
   --set-env-vars="GCS_BUCKET_NAME=your-bucket-name" \
   --set-env-vars="GCS_PREFIX=sessions" \
+  --set-env-vars="GCS_TENANT_ID=tenant-123" \
   --set-env-vars="DATA_DIR=/tmp"
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ DATA_DIR=./data
 STORAGE_PROVIDER=local  # local|gcs|firestore
 GCS_BUCKET_NAME=        # required when STORAGE_PROVIDER=gcs
 GCS_PREFIX=sessions     # optional prefix path
+GCS_TENANT_ID=tenant-123 # required when STORAGE_PROVIDER=gcs
 FIRESTORE_TENANT_ID=    # required when STORAGE_PROVIDER=firestore
 GOOGLE_APPLICATION_CREDENTIALS=path/to/cred.json  # required when STORAGE_PROVIDER=firestore
 SEARCH_PROVIDER=none   # none|cse|newsapi|hybrid
@@ -69,7 +70,7 @@ CSE_CX=                 # required when SEARCH_PROVIDER=cse or hybrid
 NEWSAPI_KEY=            # required when SEARCH_PROVIDER=newsapi or hybrid
 ```
 
-`STORAGE_PROVIDER` を `gcs` に設定する場合は `GCS_BUCKET_NAME`（必須）と必要に応じて `GCS_PREFIX` を、`firestore` に設定する場合は `FIRESTORE_TENANT_ID` と `GOOGLE_APPLICATION_CREDENTIALS` を設定してください。ローカルからGCS/Firestore にアクセスする際は `GOOGLE_APPLICATION_CREDENTIALS` にサービスアカウントJSONのパスを設定します。
+`STORAGE_PROVIDER` を `gcs` に設定する場合は `GCS_BUCKET_NAME` と `GCS_TENANT_ID`（必須）および必要に応じて `GCS_PREFIX` を、`firestore` に設定する場合は `FIRESTORE_TENANT_ID` と `GOOGLE_APPLICATION_CREDENTIALS` を設定してください。ローカルからGCS/Firestore にアクセスする際は `GOOGLE_APPLICATION_CREDENTIALS` にサービスアカウントJSONのパスを設定します。
 
 `SEARCH_PROVIDER` を `cse` または `hybrid` に設定する場合は `CSE_API_KEY` と `CSE_CX` を、`newsapi` または `hybrid` に設定する場合は `NEWSAPI_KEY` をそれぞれ設定してください。
 

--- a/env.example
+++ b/env.example
@@ -5,6 +5,7 @@ DATA_DIR=./data
 STORAGE_PROVIDER=local  # local|gcs|firestore
 GCS_BUCKET_NAME=          # required when STORAGE_PROVIDER=gcs
 GCS_PREFIX=sessions       # optional prefix path
+GCS_TENANT_ID=tenant-123   # required when STORAGE_PROVIDER=gcs
 FIRESTORE_TENANT_ID=tenant-123   # required when STORAGE_PROVIDER=firestore
 GOOGLE_APPLICATION_CREDENTIALS=./gcp-credentials.json  # required when STORAGE_PROVIDER=firestore
 SEARCH_PROVIDER=none   # none|cse|newsapi|hybrid


### PR DESCRIPTION
## Summary
- add `GCS_TENANT_ID` to `env.example`
- document `GCS_TENANT_ID` in README, AGENT guidelines, and Google Cloud migration guide

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f9852248833387017a7f4d04e393