### PR TITLE
docs: log phase 8 development kickoff

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -488,3 +488,15 @@
 ### Testing
 - `pytest -q`
 - Environment: Python 3.12.10, streamlit==1.49.1, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0
+## 2025-10-02
+### Task
+- Phase 8 development kickoff: reviewed AGENT.md and WORKLOG.md to confirm goals and progress.
+### Reviews
+1. **Python上級エンジニア視点**: ドキュメントの整合性を確認し、今後の実装範囲を明瞭化できた。
+2. **UI/UX専門家視点**: 作業開始前に進捗を明示することで、利害関係者の期待管理が容易になった。
+3. **クラウドエンジニア視点**: GCP移行方針を再確認し、フェーズ8以降のクラウド対応に備えられた。
+4. **ユーザー視点**: 機能拡張に向けた動きが可視化され、今後の改善への安心感が得られた。
+### Testing
+- `make lint`
+- `pytest -q` で 130 件のテストが成功
+- Environment: Python 3.12.10, streamlit==1.49.1, pydantic==2.11.7, jinja2==3.1.6, httpx==0.28.1, python-dotenv==1.1.1, openai==1.102.0, tenacity==9.1.2, pytest==8.4.1, google-cloud-secret-manager==2.24.0


### PR DESCRIPTION
## Summary
- log start of Phase 8 development and review of planning docs

## Testing
- `make lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b318b570c483339716375b5ca63d76